### PR TITLE
refactor: break components into atomic design system with primitives

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,12 +1,9 @@
 import { defineConfig } from "astro/config";
 import mdx from "@astrojs/mdx";
 import sitemap from "@astrojs/sitemap";
-
 // https://astro.build/config
 export default defineConfig({
-  // Production URL for sitemap/RSS; override in Vercel if preview domains differ.
   site: "https://hackmichigan.com",
-  // Root path for Vercel (or any host at domain root). Use a subpath only if deployed under one.
   base: "/",
   trailingSlash: "always",
   integrations: [mdx(), sitemap()],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,7 +10,6 @@ export default [
 
   // Astro recommended rules (flat config)
   ...astro.configs["flat/recommended"],
-
   // TS/JS rules (scoped so it doesn't override the Astro parser)
   ...tseslint.configs.recommended.map((config) => ({
     ...config,

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "prettier-plugin-astro": "^0.14.1",
         "stylelint": "^17.8.0",
         "stylelint-config-standard": "^40.0.0",
+        "stylelint-order": "^8.1.1",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.58.2"
       },
@@ -55,26 +56,17 @@
         "typescript": "^5.0.0"
       }
     },
-    "node_modules/@astrojs/check/node_modules/kleur": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
-      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/@astrojs/compiler": {
       "version": "2.13.1",
       "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.1.tgz",
       "integrity": "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@astrojs/internal-helpers": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.7.5.tgz",
-      "integrity": "sha512-vreGnYSSKhAjFJCWAwe/CNhONvoc5lokxtRoZims+0wa3KbHBdPHSSthJsKxPd8d/aic6lWKpRTYGY/hsgK6EA==",
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.7.6.tgz",
+      "integrity": "sha512-GOle7smBWKfMSP8osUIGOlB5kaHdQLV3foCsf+5Q9Wsuu+C6Fs3Ez/ttXmhjZ1HkSgsogcM1RXSjjOVieHq16Q==",
       "license": "MIT"
     },
     "node_modules/@astrojs/language-server": {
@@ -120,12 +112,12 @@
       }
     },
     "node_modules/@astrojs/markdown-remark": {
-      "version": "6.3.10",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-6.3.10.tgz",
-      "integrity": "sha512-kk4HeYR6AcnzC4QV8iSlOfh+N8TZ3MEStxPyenyCtemqn8IpEATBFMTJcfrNW32dgpt6MY3oCkMM/Tv3/I4G3A==",
+      "version": "6.3.11",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-6.3.11.tgz",
+      "integrity": "sha512-hcaxX/5aC6lQgHeGh1i+aauvSwIT6cfyFjKWvExYSxUhZZBBdvCliOtu06gbQyhbe0pGJNoNmqNlQZ5zYUuIyQ==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/internal-helpers": "0.7.5",
+        "@astrojs/internal-helpers": "0.7.6",
         "@astrojs/prism": "3.3.0",
         "github-slugger": "^2.0.0",
         "hast-util-from-html": "^2.0.3",
@@ -139,8 +131,8 @@
         "remark-parse": "^11.0.0",
         "remark-rehype": "^11.1.2",
         "remark-smartypants": "^3.0.2",
-        "shiki": "^3.19.0",
-        "smol-toml": "^1.5.2",
+        "shiki": "^3.21.0",
+        "smol-toml": "^1.6.0",
         "unified": "^11.0.5",
         "unist-util-remove-position": "^5.0.0",
         "unist-util-visit": "^5.0.0",
@@ -149,12 +141,12 @@
       }
     },
     "node_modules/@astrojs/mdx": {
-      "version": "4.3.13",
-      "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-4.3.13.tgz",
-      "integrity": "sha512-IHDHVKz0JfKBy3//52JSiyWv089b7GVSChIXLrlUOoTLWowG3wr2/8hkaEgEyd/vysvNQvGk+QhysXpJW5ve6Q==",
+      "version": "4.3.14",
+      "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-4.3.14.tgz",
+      "integrity": "sha512-FBrqJQORVm+rkRa2TS5CjU9PBA6hkhrwLVBSS9A77gN2+iehvjq1w6yya/d0YKC7osiVorKkr3Qd9wNbl0ZkGA==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/markdown-remark": "6.3.10",
+        "@astrojs/markdown-remark": "6.3.11",
         "@mdx-js/mdx": "^3.1.1",
         "acorn": "^8.15.0",
         "es-module-lexer": "^1.7.0",
@@ -188,24 +180,25 @@
       }
     },
     "node_modules/@astrojs/rss": {
-      "version": "4.0.13",
-      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-4.0.13.tgz",
-      "integrity": "sha512-ugW4DmGn8kgfl8/qecU3EcKCAuEBrZqY7eYfa6at0sY7HGEwRdzsOafLE437RwDMP2ZuxfKnCNABs99YVhX0kg==",
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-4.0.18.tgz",
+      "integrity": "sha512-wc5DwKlbTEdgVAWnHy8krFTeQ42t1v/DJqeq5HtulYK3FYHE4krtRGjoyhS3eXXgfdV6Raoz2RU3wrMTFAitRg==",
       "license": "MIT",
       "dependencies": {
-        "fast-xml-parser": "^5.3.0",
-        "picocolors": "^1.1.1"
+        "fast-xml-parser": "^5.5.7",
+        "piccolore": "^0.1.3",
+        "zod": "^4.3.6"
       }
     },
     "node_modules/@astrojs/sitemap": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.6.0.tgz",
-      "integrity": "sha512-4aHkvcOZBWJigRmMIAJwRQXBS+ayoP5z40OklTXYXhUDhwusz+DyDl+nSshY6y9DvkVEavwNcFO8FD81iGhXjg==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.7.2.tgz",
+      "integrity": "sha512-PqkzkcZTb5ICiyIR8VoKbIAP/laNRXi5tw616N1Ckk+40oNB8Can1AzVV56lrbC5GKSZFCyJYUVYqVivMisvpA==",
       "license": "MIT",
       "dependencies": {
-        "sitemap": "^8.0.0",
+        "sitemap": "^9.0.0",
         "stream-replace-string": "^2.0.0",
-        "zod": "^3.25.76"
+        "zod": "^4.3.6"
       }
     },
     "node_modules/@astrojs/telemetry": {
@@ -277,12 +270,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
-      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.5"
+        "@babel/types": "^7.29.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -292,9 +285,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
-      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -340,6 +333,7 @@
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -417,6 +411,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -465,6 +460,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -602,9 +598,9 @@
       "license": "MIT"
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.7.1.tgz",
-      "integrity": "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -612,9 +608,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
-      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
       "cpu": [
         "ppc64"
       ],
@@ -628,9 +624,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
-      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
       "cpu": [
         "arm"
       ],
@@ -644,9 +640,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
-      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
       "cpu": [
         "arm64"
       ],
@@ -660,9 +656,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
-      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
       "cpu": [
         "x64"
       ],
@@ -676,9 +672,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
-      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
       "cpu": [
         "arm64"
       ],
@@ -692,9 +688,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
-      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
       "cpu": [
         "x64"
       ],
@@ -708,9 +704,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
       "cpu": [
         "arm64"
       ],
@@ -724,9 +720,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
-      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
       "cpu": [
         "x64"
       ],
@@ -740,9 +736,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
-      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
       "cpu": [
         "arm"
       ],
@@ -756,9 +752,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
-      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
       "cpu": [
         "arm64"
       ],
@@ -772,9 +768,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
-      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
       "cpu": [
         "ia32"
       ],
@@ -788,9 +784,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
-      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
       "cpu": [
         "loong64"
       ],
@@ -804,9 +800,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
-      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
       "cpu": [
         "mips64el"
       ],
@@ -820,9 +816,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
-      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
       "cpu": [
         "ppc64"
       ],
@@ -836,9 +832,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
-      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
       "cpu": [
         "riscv64"
       ],
@@ -852,9 +848,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
-      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
       "cpu": [
         "s390x"
       ],
@@ -868,9 +864,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
-      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
       "cpu": [
         "x64"
       ],
@@ -884,9 +880,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
       "cpu": [
         "arm64"
       ],
@@ -900,9 +896,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
       "cpu": [
         "x64"
       ],
@@ -916,9 +912,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
       "cpu": [
         "arm64"
       ],
@@ -932,9 +928,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
       "cpu": [
         "x64"
       ],
@@ -948,9 +944,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
-      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
       "cpu": [
         "arm64"
       ],
@@ -964,9 +960,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
-      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
       "cpu": [
         "x64"
       ],
@@ -980,9 +976,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
-      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
       "cpu": [
         "arm64"
       ],
@@ -996,9 +992,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
-      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
       "cpu": [
         "ia32"
       ],
@@ -1012,9 +1008,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
-      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
       "cpu": [
         "x64"
       ],
@@ -1122,25 +1118,39 @@
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }
@@ -1174,9 +1184,9 @@
       }
     },
     "node_modules/@img/colour": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz",
-      "integrity": "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -1689,6 +1699,18 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1775,9 +1797,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
-      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
       "cpu": [
         "arm"
       ],
@@ -1788,9 +1810,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
-      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
       "cpu": [
         "arm64"
       ],
@@ -1801,9 +1823,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
-      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
       "cpu": [
         "arm64"
       ],
@@ -1814,9 +1836,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
-      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
       "cpu": [
         "x64"
       ],
@@ -1827,9 +1849,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
-      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
       "cpu": [
         "arm64"
       ],
@@ -1840,9 +1862,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
-      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
       "cpu": [
         "x64"
       ],
@@ -1853,9 +1875,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
-      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
       "cpu": [
         "arm"
       ],
@@ -1866,9 +1888,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
-      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
       "cpu": [
         "arm"
       ],
@@ -1879,9 +1901,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
-      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
       "cpu": [
         "arm64"
       ],
@@ -1892,9 +1914,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
-      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
       "cpu": [
         "arm64"
       ],
@@ -1905,9 +1927,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
-      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
       "cpu": [
         "loong64"
       ],
@@ -1918,9 +1940,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
-      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
       "cpu": [
         "loong64"
       ],
@@ -1931,9 +1953,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
-      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
       "cpu": [
         "ppc64"
       ],
@@ -1944,9 +1966,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
-      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1957,9 +1979,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
-      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
       "cpu": [
         "riscv64"
       ],
@@ -1970,9 +1992,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
-      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1983,9 +2005,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
-      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
       "cpu": [
         "s390x"
       ],
@@ -1996,9 +2018,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
-      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
       "cpu": [
         "x64"
       ],
@@ -2009,9 +2031,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
-      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
       "cpu": [
         "x64"
       ],
@@ -2022,9 +2044,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
-      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
       "cpu": [
         "x64"
       ],
@@ -2035,9 +2057,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
-      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
       "cpu": [
         "arm64"
       ],
@@ -2048,9 +2070,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
-      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
       "cpu": [
         "arm64"
       ],
@@ -2061,9 +2083,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
-      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
       "cpu": [
         "ia32"
       ],
@@ -2074,9 +2096,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
-      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
       "cpu": [
         "x64"
       ],
@@ -2087,9 +2109,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
-      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
       "cpu": [
         "x64"
       ],
@@ -2180,9 +2202,9 @@
       }
     },
     "node_modules/@types/debug": {
-      "version": "4.1.12",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
-      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
       "license": "MIT",
       "dependencies": {
         "@types/ms": "*"
@@ -2257,9 +2279,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.10.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
-      "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -2342,6 +2364,7 @@
       "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.2",
         "@typescript-eslint/types": "8.58.2",
@@ -2691,6 +2714,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2708,35 +2732,20 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-draft-04": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
-      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "ajv": "^8.5.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
       }
     },
     "node_modules/ansi-align": {
@@ -2802,12 +2811,16 @@
       }
     },
     "node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
       "engines": {
-        "node": ">=12"
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
@@ -2893,6 +2906,7 @@
       "resolved": "https://registry.npmjs.org/astro/-/astro-5.18.1.tgz",
       "integrity": "sha512-m4VWilWZ+Xt6NPoYzC4CgGZim/zQUO7WFL0RHCH0AiEavF1153iC3+me2atDvXpf/yX4PyGUeD8wZLq1cirT3g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@astrojs/compiler": "^2.13.0",
         "@astrojs/internal-helpers": "0.7.6",
@@ -3001,36 +3015,6 @@
         "url": "https://github.com/sponsors/ota-meshi"
       }
     },
-    "node_modules/astro-eslint-parser/node_modules/entities": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
-      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/astro-eslint-parser/node_modules/eslint-scope": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
-      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^5.2.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
     "node_modules/astro-eslint-parser/node_modules/eslint-visitor-keys": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
@@ -3044,514 +3028,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/astro-eslint-parser/node_modules/espree": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "acorn": "^8.15.0",
-        "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
+    "node_modules/astro/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "peer": true,
       "funding": {
-        "url": "https://opencollective.com/eslint"
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
-    "node_modules/astro/node_modules/@astrojs/internal-helpers": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.7.6.tgz",
-      "integrity": "sha512-GOle7smBWKfMSP8osUIGOlB5kaHdQLV3foCsf+5Q9Wsuu+C6Fs3Ez/ttXmhjZ1HkSgsogcM1RXSjjOVieHq16Q==",
-      "license": "MIT"
-    },
-    "node_modules/astro/node_modules/@astrojs/markdown-remark": {
-      "version": "6.3.11",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-6.3.11.tgz",
-      "integrity": "sha512-hcaxX/5aC6lQgHeGh1i+aauvSwIT6cfyFjKWvExYSxUhZZBBdvCliOtu06gbQyhbe0pGJNoNmqNlQZ5zYUuIyQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@astrojs/internal-helpers": "0.7.6",
-        "@astrojs/prism": "3.3.0",
-        "github-slugger": "^2.0.0",
-        "hast-util-from-html": "^2.0.3",
-        "hast-util-to-text": "^4.0.2",
-        "import-meta-resolve": "^4.2.0",
-        "js-yaml": "^4.1.1",
-        "mdast-util-definitions": "^6.0.0",
-        "rehype-raw": "^7.0.0",
-        "rehype-stringify": "^10.0.1",
-        "remark-gfm": "^4.0.1",
-        "remark-parse": "^11.0.0",
-        "remark-rehype": "^11.1.2",
-        "remark-smartypants": "^3.0.2",
-        "shiki": "^3.21.0",
-        "smol-toml": "^1.6.0",
-        "unified": "^11.0.5",
-        "unist-util-remove-position": "^5.0.0",
-        "unist-util-visit": "^5.0.0",
-        "unist-util-visit-parents": "^6.0.2",
-        "vfile": "^6.0.3"
-      }
-    },
-    "node_modules/astro/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/astro/node_modules/@esbuild/android-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/astro/node_modules/@esbuild/android-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/astro/node_modules/@esbuild/android-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/astro/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/astro/node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/astro/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/astro/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/astro/node_modules/@esbuild/linux-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/astro/node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/astro/node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/astro/node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
-      "cpu": [
-        "loong64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/astro/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/astro/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/astro/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/astro/node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/astro/node_modules/@esbuild/linux-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/astro/node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/astro/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/astro/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/astro/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/astro/node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/astro/node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/astro/node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/astro/node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/astro/node_modules/@esbuild/win32-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/astro/node_modules/esbuild": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.7",
-        "@esbuild/android-arm": "0.27.7",
-        "@esbuild/android-arm64": "0.27.7",
-        "@esbuild/android-x64": "0.27.7",
-        "@esbuild/darwin-arm64": "0.27.7",
-        "@esbuild/darwin-x64": "0.27.7",
-        "@esbuild/freebsd-arm64": "0.27.7",
-        "@esbuild/freebsd-x64": "0.27.7",
-        "@esbuild/linux-arm": "0.27.7",
-        "@esbuild/linux-arm64": "0.27.7",
-        "@esbuild/linux-ia32": "0.27.7",
-        "@esbuild/linux-loong64": "0.27.7",
-        "@esbuild/linux-mips64el": "0.27.7",
-        "@esbuild/linux-ppc64": "0.27.7",
-        "@esbuild/linux-riscv64": "0.27.7",
-        "@esbuild/linux-s390x": "0.27.7",
-        "@esbuild/linux-x64": "0.27.7",
-        "@esbuild/netbsd-arm64": "0.27.7",
-        "@esbuild/netbsd-x64": "0.27.7",
-        "@esbuild/openbsd-arm64": "0.27.7",
-        "@esbuild/openbsd-x64": "0.27.7",
-        "@esbuild/openharmony-arm64": "0.27.7",
-        "@esbuild/sunos-x64": "0.27.7",
-        "@esbuild/win32-arm64": "0.27.7",
-        "@esbuild/win32-ia32": "0.27.7",
-        "@esbuild/win32-x64": "0.27.7"
+    "node_modules/astro/node_modules/zod-to-ts": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/zod-to-ts/-/zod-to-ts-1.2.0.tgz",
+      "integrity": "sha512-x30XE43V+InwGpvTySRNz9kB7qFU8DlyEy7BsSTCHPH1R0QasMmHWZDCzYm6bVXtj/9NNJAZF3jW8rzFvH5OFA==",
+      "peerDependencies": {
+        "typescript": "^4.9.4 || ^5.0.2",
+        "zod": "^3"
       }
     },
     "node_modules/astrojs-compiler-sync": {
@@ -3787,9 +3280,9 @@
       }
     },
     "node_modules/ci-info": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
-      "integrity": "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
       "funding": [
         {
           "type": "github",
@@ -3836,22 +3329,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/cliui/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/cliui/node_modules/emoji-regex": {
@@ -4162,9 +3639,9 @@
       }
     },
     "node_modules/decode-named-character-reference": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.2.0.tgz",
-      "integrity": "sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
       "license": "MIT",
       "dependencies": {
         "character-entities": "^2.0.0"
@@ -4358,9 +3835,10 @@
       "license": "MIT"
     },
     "node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -4428,9 +3906,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
-      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -4440,32 +3918,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.12",
-        "@esbuild/android-arm": "0.25.12",
-        "@esbuild/android-arm64": "0.25.12",
-        "@esbuild/android-x64": "0.25.12",
-        "@esbuild/darwin-arm64": "0.25.12",
-        "@esbuild/darwin-x64": "0.25.12",
-        "@esbuild/freebsd-arm64": "0.25.12",
-        "@esbuild/freebsd-x64": "0.25.12",
-        "@esbuild/linux-arm": "0.25.12",
-        "@esbuild/linux-arm64": "0.25.12",
-        "@esbuild/linux-ia32": "0.25.12",
-        "@esbuild/linux-loong64": "0.25.12",
-        "@esbuild/linux-mips64el": "0.25.12",
-        "@esbuild/linux-ppc64": "0.25.12",
-        "@esbuild/linux-riscv64": "0.25.12",
-        "@esbuild/linux-s390x": "0.25.12",
-        "@esbuild/linux-x64": "0.25.12",
-        "@esbuild/netbsd-arm64": "0.25.12",
-        "@esbuild/netbsd-x64": "0.25.12",
-        "@esbuild/openbsd-arm64": "0.25.12",
-        "@esbuild/openbsd-x64": "0.25.12",
-        "@esbuild/openharmony-arm64": "0.25.12",
-        "@esbuild/sunos-x64": "0.25.12",
-        "@esbuild/win32-arm64": "0.25.12",
-        "@esbuild/win32-ia32": "0.25.12",
-        "@esbuild/win32-x64": "0.25.12"
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/escalade": {
@@ -4479,30 +3957,32 @@
       }
     },
     "node_modules/escape-string-regexp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.0.tgz",
-      "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.1.tgz",
+      "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
-        "@eslint/config-array": "^0.23.4",
-        "@eslint/config-helpers": "^0.5.4",
-        "@eslint/core": "^1.2.0",
-        "@eslint/plugin-kit": "^0.7.0",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.5.5",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
@@ -4589,19 +4069,17 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
-      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@types/esrecurse": "^4.3.1",
-        "@types/estree": "^1.0.8",
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -4620,34 +4098,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+    "node_modules/eslint/node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
       "dev": true,
-      "license": "MIT",
+      "license": "BSD-2-Clause",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
       },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/eslint/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
-      "license": "MIT",
       "engines": {
-        "node": ">=10"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
@@ -4663,24 +4130,7 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/ignore": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/eslint/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/espree": {
+    "node_modules/eslint/node_modules/espree": {
       "version": "11.2.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
       "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
@@ -4698,14 +4148,42 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/espree/node_modules/eslint-visitor-keys": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -4849,9 +4327,9 @@
       }
     },
     "node_modules/eventemitter3": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
     },
     "node_modules/extend": {
@@ -4929,9 +4407,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
       "funding": [
         {
           "type": "github",
@@ -4944,9 +4422,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.11",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.11.tgz",
-      "integrity": "sha512-QL0eb0YbSTVWF6tTf1+LEMSgtCEjBYPpnAjoLC8SscESlAjXEIRJ7cHtLG0pLeDFaZLa4VKZLArtA/60ZS7vyA==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
+      "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
       "funding": [
         {
           "type": "github",
@@ -4955,8 +4433,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.4.0",
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
         "strnum": "^2.2.3"
       },
       "bin": {
@@ -5819,9 +5298,9 @@
       }
     },
     "node_modules/is-wsl": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
-      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
       "license": "MIT",
       "dependencies": {
         "is-inside-container": "^1.0.0"
@@ -5874,9 +5353,9 @@
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
     },
@@ -5915,9 +5394,10 @@
       }
     },
     "node_modules/kleur": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5978,9 +5458,9 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "11.3.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
-      "integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -5996,13 +5476,13 @@
       }
     },
     "node_modules/magicast": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.1.tgz",
-      "integrity": "sha512-xrHS24IxaLrvuo613F719wvOIv9xPHFWQHuvGUBmPnCA/3MQxKI3b+r7n1jAoDHmsbC5bRhTZYR77invLAxVnw==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.5",
-        "@babel/types": "^7.28.5",
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
         "source-map-js": "^1.2.1"
       }
     },
@@ -6070,10 +5550,22 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/mdast-util-from-markdown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
-      "integrity": "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -7472,6 +6964,18 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/path-browserify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
@@ -7557,6 +7061,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7605,12 +7110,23 @@
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/postcss-sorting": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-sorting/-/postcss-sorting-10.0.0.tgz",
+      "integrity": "sha512-TXbU+h6vVRW+86c/+ewhWq9k7pr7ijASTnepVhCQiC87zAOTkvB1v2dHyWP+ggstSTX/PNvjzS+IOqzejndz9w==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "postcss": "^8.4.20"
       }
     },
     "node_modules/postcss-value-parser": {
@@ -7636,6 +7152,7 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -7652,6 +7169,7 @@
       "integrity": "sha512-RiBETaaP9veVstE4vUwSIcdATj6dKmXljouXc/DDNwBSPTp8FRkLGDSGFClKsAFeeg+13SB0Z1JZvbD76bigJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@astrojs/compiler": "^2.9.1",
         "prettier": "^3.0.0",
@@ -7681,6 +7199,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/prompts/node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/property-information": {
@@ -8136,9 +7663,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
-      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -8151,31 +7678,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.1",
-        "@rollup/rollup-android-arm64": "4.60.1",
-        "@rollup/rollup-darwin-arm64": "4.60.1",
-        "@rollup/rollup-darwin-x64": "4.60.1",
-        "@rollup/rollup-freebsd-arm64": "4.60.1",
-        "@rollup/rollup-freebsd-x64": "4.60.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
-        "@rollup/rollup-linux-arm64-musl": "4.60.1",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
-        "@rollup/rollup-linux-loong64-musl": "4.60.1",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
-        "@rollup/rollup-linux-x64-gnu": "4.60.1",
-        "@rollup/rollup-linux-x64-musl": "4.60.1",
-        "@rollup/rollup-openbsd-x64": "4.60.1",
-        "@rollup/rollup-openharmony-arm64": "4.60.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
-        "@rollup/rollup-win32-x64-gnu": "4.60.1",
-        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
         "fsevents": "~2.3.2"
       }
     },
@@ -8230,9 +7757,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -8345,29 +7872,23 @@
       "license": "MIT"
     },
     "node_modules/sitemap": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-8.0.2.tgz",
-      "integrity": "sha512-LwktpJcyZDoa0IL6KT++lQ53pbSrx2c9ge41/SeLTyqy2XUNA6uR4+P9u5IVo5lPeL2arAcOKn1aZAxoYbCKlQ==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-9.0.1.tgz",
+      "integrity": "sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==",
       "license": "MIT",
       "dependencies": {
-        "@types/node": "^17.0.5",
+        "@types/node": "^24.9.2",
         "@types/sax": "^1.2.1",
         "arg": "^5.0.0",
         "sax": "^1.4.1"
       },
       "bin": {
-        "sitemap": "dist/cli.js"
+        "sitemap": "dist/esm/cli.js"
       },
       "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=6.0.0"
+        "node": ">=20.19.5",
+        "npm": ">=10.8.2"
       }
-    },
-    "node_modules/sitemap/node_modules/@types/node": {
-      "version": "17.0.45",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
-      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
-      "license": "MIT"
     },
     "node_modules/slash": {
       "version": "5.1.0",
@@ -8398,22 +7919,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-      }
-    },
-    "node_modules/slice-ansi/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/smol-toml": {
@@ -8494,12 +7999,12 @@
       }
     },
     "node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
         "node": ">=12"
@@ -8554,6 +8059,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@csstools/css-calc": "^3.1.1",
         "@csstools/css-parser-algorithms": "^4.0.0",
@@ -8646,6 +8152,23 @@
       },
       "peerDependencies": {
         "stylelint": "^17.0.0"
+      }
+    },
+    "node_modules/stylelint-order": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/stylelint-order/-/stylelint-order-8.1.1.tgz",
+      "integrity": "sha512-LqsEB6VggJuu5v10RtkrQsBObcdwBE7GuAOlwfc/LR3VL/w8UqKX2BOLIjhyGt0Gne/njo7gRNGiJAKhfmPMNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss": "^8.5.8",
+        "postcss-sorting": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "stylelint": "^16.18.0 || ^17.0.0"
       }
     },
     "node_modules/stylelint/node_modules/file-entry-cache": {
@@ -8818,6 +8341,23 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/table/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/table/node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -8832,6 +8372,13 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/table/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
     },
@@ -8876,22 +8423,22 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
-      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -9010,6 +8557,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9214,9 +8762,9 @@
       }
     },
     "node_modules/unist-util-visit": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
-      "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -9512,10 +9060,467 @@
         }
       }
     },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
     "node_modules/vitefu": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.1.tgz",
-      "integrity": "sha512-B/Fegf3i8zh0yFbpzZ21amWzHmuNlLlmJT6n7bu5e+pCHUKQIfXSYokrqOBGEMMe9UG2sostKQF9mml/vYaWJQ==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
+      "integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
       "license": "MIT",
       "workspaces": [
         "tests/deps/*",
@@ -9523,7 +9528,7 @@
         "tests/projects/workspace/packages/*"
       ],
       "peerDependencies": {
-        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0"
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "vite": {
@@ -9863,6 +9868,18 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/write-file-atomic": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-7.0.1.tgz",
@@ -9898,6 +9915,7 @@
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "devOptional": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -9930,6 +9948,46 @@
       "bin": {
         "yaml-language-server": "bin/yaml-language-server"
       }
+    },
+    "node_modules/yaml-language-server/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/yaml-language-server/node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yaml-language-server/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yaml-language-server/node_modules/request-light": {
       "version": "0.5.8",
@@ -10051,30 +10109,22 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zod-to-json-schema": {
-      "version": "3.25.1",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
-      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "license": "ISC",
       "peerDependencies": {
-        "zod": "^3.25 || ^4"
-      }
-    },
-    "node_modules/zod-to-ts": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/zod-to-ts/-/zod-to-ts-1.2.0.tgz",
-      "integrity": "sha512-x30XE43V+InwGpvTySRNz9kB7qFU8DlyEy7BsSTCHPH1R0QasMmHWZDCzYm6bVXtj/9NNJAZF3jW8rzFvH5OFA==",
-      "peerDependencies": {
-        "typescript": "^4.9.4 || ^5.0.2",
-        "zod": "^3"
+        "zod": "^3.25.28 || ^4"
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "lint:css": "stylelint \"src/**/*.{css,astro}\"",
-    "lint:css:fix": "stylelint \"src/**/*.{css,astro}\" --fix"
+    "lint:css:fix": "stylelint \"src/**/*.{css,astro}\" --fix",
+    "typecheck": "astro check",
+    "verify": "npm run format:check && npm run lint && npm run lint:css && npm run typecheck && npm run build"
   },
   "dependencies": {
     "@astrojs/mdx": "^4.0.0",
@@ -56,6 +58,7 @@
     "prettier-plugin-astro": "^0.14.1",
     "stylelint": "^17.8.0",
     "stylelint-config-standard": "^40.0.0",
+    "stylelint-order": "^8.1.1",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.58.2"
   },

--- a/src/components/AboutSection.astro
+++ b/src/components/AboutSection.astro
@@ -1,169 +1,144 @@
 ---
-// About HackMI — mission copy (refine when programming is finalized)
+import GlassCard from "./primitives/GlassCard.astro";
+import Section from "./primitives/Section.astro";
+import SectionHeader from "./primitives/SectionHeader.astro";
 ---
 
-<section class="about-section" id="about" aria-labelledby="about-heading">
-  <div class="container">
-    <h2 id="about-heading" class="section-title">About Hack Michigan</h2>
-    <p class="section-subtitle">
-      Michigan was built by innovators and it's time to innovate again. Our
-      state leads in manufacturing, agriculture, and mobility, but too many
-      Michigan businesses still rely on outdated systems, and too many of our
-      brightest minds leave for opportunities elsewhere. Your challenge: use AI
-      and Open Source technologies to build a proof-of-concept AI solution that
-      modernizes a Michigan industry whether that's manufacturing, small
-      business, mobility, agriculture, sustainability, education, or urban
-      planning. Show us how AI can solve a real problem, create real value, and
-      keep innovation rooted right here in Michigan. Deliver a working prototype
-      and a brief presentation that tells the story of how your solution
-      strengthens Michigan's future.
-    </p>
-    <div class="about-card glass">
-      <div class="details">
-        <h3 class="section-title">The Challenge</h3>
-        <p class="about-description">
-          Michigan stands at a pivotal moment. Once the undisputed engine of
-          American innovation, our state is ready to reclaim its position as a
-          technology leader—not by abandoning our industrial heritage, but by
-          reimagining it for the 21st century.
-        </p>
-        <p>
-          While Michigan ranks among the top states in manufacturing output, we
-          lag behind in technology adoption and digital transformation metrics.
-          Too often, our brightest minds leave for coastal tech hubs, and
-          Michigan jobs get outsourced to other states or overseas. Our
-          challenge is clear: how do we leverage cutting-edge AI to modernize
-          Michigan’s cornerstone industries while keeping opportunities here for
-          Michiganders and creating the innovation ecosystem that makes our
-          state a destination, not a departure point?
-        </p>
-        <h3 class="section-title">The Stats Tell the Story</h3>
-        <ul class="about-list">
-          <li>
-            Michigan graduates leave the state at higher rates than most,
-            seeking tech opportunities elsewhere
-          </li>
-          <li>
-            Many legacy industries still operate with outdated systems and
-            manual processes
-          </li>
-          <li>
-            Small and medium-sized Michigan businesses cite technology adoption
-            as their #1 barrier to growth
-          </li>
-          <li>
-            Brain drain continues as innovators lack the infrastructure and
-            community to build here
-          </li>
-          <li>
-            Immense untapped potential in AI-driven innovation across
-            manufacturing, supply chain, agriculture, sustainability, education,
-            and urban development
-          </li>
-        </ul>
+<Section
+  id="about"
+  labelledBy="about-heading"
+  width="narrow"
+  padding="default"
+  style="padding-bottom: 3rem;"
+>
+  <SectionHeader
+    id="about-heading"
+    title="About Hack Michigan"
+    align="center"
+  />
+  <p class="about-mission">
+    Michigan was built by innovators and it's time to innovate again. Our state
+    leads in manufacturing, agriculture, and mobility, but too many Michigan
+    businesses still rely on outdated systems, and too many of our brightest
+    minds leave for opportunities elsewhere. Your challenge: use AI and Open
+    Source technologies to build a proof-of-concept AI solution that modernizes
+    a Michigan industry whether that's manufacturing, small business, mobility,
+    agriculture, sustainability, education, or urban planning. Show us how AI
+    can solve a real problem, create real value, and keep innovation rooted
+    right here in Michigan. Deliver a working prototype and a brief presentation
+    that tells the story of how your solution strengthens Michigan's future.
+  </p>
 
-        <h3 class="section-title">What We're Asking You To Build</h3>
-        <p>
-          Using AI and Open Source technologies, build an innovative
-          proof-of-concept solution that addresses one of the following focus
-          areas:
-        </p>
+  <GlassCard class="about-card">
+    <div class="details">
+      <h3 class="section-title">The Challenge</h3>
+      <p class="about-description">
+        Michigan stands at a pivotal moment. Once the undisputed engine of
+        American innovation, our state is ready to reclaim its position as a
+        technology leader—not by abandoning our industrial heritage, but by
+        reimagining it for the 21st century.
+      </p>
+      <p>
+        While Michigan ranks among the top states in manufacturing output, we
+        lag behind in technology adoption and digital transformation metrics.
+        Too often, our brightest minds leave for coastal tech hubs, and Michigan
+        jobs get outsourced to other states or overseas. Our challenge is clear:
+        how do we leverage cutting-edge AI to modernize Michigan's cornerstone
+        industries while keeping opportunities here for Michiganders and
+        creating the innovation ecosystem that makes our state a destination,
+        not a departure point?
+      </p>
 
-        <ul class="about-list">
-          <li>
-            Modernizing Michigan Manufacturing — Transform traditional
-            manufacturing processes with AI-powered automation, predictive
-            maintenance, quality control, or supply chain optimization that
-            keeps production and jobs in Michigan.
-          </li>
+      <h3 class="section-title">The Stats Tell the Story</h3>
+      <ul class="about-list">
+        <li>
+          Michigan graduates leave the state at higher rates than most, seeking
+          tech opportunities elsewhere
+        </li>
+        <li>
+          Many legacy industries still operate with outdated systems and manual
+          processes
+        </li>
+        <li>
+          Small and medium-sized Michigan businesses cite technology adoption as
+          their #1 barrier to growth
+        </li>
+        <li>
+          Brain drain continues as innovators lack the infrastructure and
+          community to build here
+        </li>
+        <li>
+          Immense untapped potential in AI-driven innovation across
+          manufacturing, supply chain, agriculture, sustainability, education,
+          and urban development
+        </li>
+      </ul>
 
-          <li>
-            Reinvigorating Main Street — Empower Michigan's small businesses and
-            retailers with accessible AI tools for customer engagement,
-            inventory management, market analysis, or operations that help them
-            compete without outsourcing.
-          </li>
+      <h3 class="section-title">What We're Asking You To Build</h3>
+      <p>
+        Using AI and Open Source technologies, build an innovative
+        proof-of-concept solution that addresses one of the following focus
+        areas:
+      </p>
 
-          <li>
-            Next-Gen Mobility — Reimagine transportation and logistics for
-            Michigan's automotive future through autonomous systems, smart
-            infrastructure, or connected vehicle technologies developed and
-            deployed here.
-          </li>
-
-          <li>
-            Agricultural Innovation — Enhance Michigan's agricultural sector
-            with AI-driven solutions for crop management, sustainability,
-            precision farming, or food supply chain optimization.
-          </li>
-
-          <li>
-            Building Michigan's Innovation Ecosystem — Create tools, platforms,
-            or solutions that help Michigan entrepreneurs, developers, and
-            innovators collaborate, access resources, prototype ideas, or scale
-            their ventures without leaving the state.
-          </li>
-
-          <li>
-            Sustainability & Clean Energy — Develop AI solutions that advance
-            environmental sustainability in Michigan from optimizing energy
-            consumption in manufacturing to monitoring Great Lakes water
-            quality, managing renewable energy grids, reducing waste, or
-            supporting Michigan's transition to a greener economy.
-          </li>
-
-          <li>
-            Education & Workforce Development — Build AI-powered tools that
-            transform learning for Michigan's K-12 students and adult learners
-            alike whether through personalized tutoring, skills gap analysis,
-            workforce retraining platforms, career pathway guidance, or making
-            quality education more accessible across rural and urban Michigan.
-          </li>
-
-          <li>
-            Smart Urban Planning & Community Development — Leverage AI to help
-            Michigan cities and communities plan smarter from optimizing public
-            transit routes and predicting infrastructure needs to revitalizing
-            neighborhoods, improving public safety, managing housing data, or
-            making city services more responsive and equitable.
-          </li>
-        </ul>
-      </div>
+      <ul class="about-list">
+        <li>
+          Modernizing Michigan Manufacturing — Transform traditional
+          manufacturing processes with AI-powered automation, predictive
+          maintenance, quality control, or supply chain optimization that keeps
+          production and jobs in Michigan.
+        </li>
+        <li>
+          Reinvigorating Main Street — Empower Michigan's small businesses and
+          retailers with accessible AI tools for customer engagement, inventory
+          management, market analysis, or operations that help them compete
+          without outsourcing.
+        </li>
+        <li>
+          Next-Gen Mobility — Reimagine transportation and logistics for
+          Michigan's automotive future through autonomous systems, smart
+          infrastructure, or connected vehicle technologies developed and
+          deployed here.
+        </li>
+        <li>
+          Agricultural Innovation — Enhance Michigan's agricultural sector with
+          AI-driven solutions for crop management, sustainability, precision
+          farming, or food supply chain optimization.
+        </li>
+        <li>
+          Building Michigan's Innovation Ecosystem — Create tools, platforms, or
+          solutions that help Michigan entrepreneurs, developers, and innovators
+          collaborate, access resources, prototype ideas, or scale their
+          ventures without leaving the state.
+        </li>
+        <li>
+          Sustainability & Clean Energy — Develop AI solutions that advance
+          environmental sustainability in Michigan from optimizing energy
+          consumption in manufacturing to monitoring Great Lakes water quality,
+          managing renewable energy grids, reducing waste, or supporting
+          Michigan's transition to a greener economy.
+        </li>
+        <li>
+          Education & Workforce Development — Build AI-powered tools that
+          transform learning for Michigan's K-12 students and adult learners
+          alike whether through personalized tutoring, skills gap analysis,
+          workforce retraining platforms, career pathway guidance, or making
+          quality education more accessible across rural and urban Michigan.
+        </li>
+        <li>
+          Smart Urban Planning & Community Development — Leverage AI to help
+          Michigan cities and communities plan smarter from optimizing public
+          transit routes and predicting infrastructure needs to revitalizing
+          neighborhoods, improving public safety, managing housing data, or
+          making city services more responsive and equitable.
+        </li>
+      </ul>
     </div>
-  </div>
-</section>
+  </GlassCard>
+</Section>
 
 <style>
-  .about-section {
-    padding: 5rem 2rem 3rem;
-    position: relative;
-  }
-
-  .about-description {
-    font-family: var(--font-body);
-    font-size: clamp(1.25rem, 3vw, 1.5rem);
-    color: var(--color-text);
-    margin-bottom: 1.5rem;
-    font-weight: 500;
-  }
-
-  .container {
-    max-width: 900px;
-    margin: 0 auto;
-  }
-
-  .section-title {
-    font-family: var(--font-heading);
-    font-size: clamp(2rem, 5vw, 3rem);
-    font-weight: 700;
-    text-transform: uppercase;
-    text-align: center;
-    margin-bottom: 0.75rem;
-    margin-block-start: 2rem;
-    color: var(--color-accent-green);
-  }
-
-  .section-subtitle {
+  .about-mission {
     text-align: start;
     line-height: 1.85;
     color: var(--color-text-dim);
@@ -171,9 +146,14 @@
     margin-bottom: 2rem;
   }
 
-  .about-card {
-    padding: 2rem 2.25rem;
-    border-radius: 1rem;
+  /* .about-card padding is in global.css (cross-component override) */
+
+  .about-description {
+    font-family: var(--font-body);
+    font-size: clamp(1.25rem, 3vw, 1.5rem);
+    color: var(--color-text);
+    margin-bottom: 1.5rem;
+    font-weight: 500;
   }
 
   .about-list {
@@ -192,39 +172,5 @@
   .details p {
     line-height: 1.65;
     font-size: clamp(0.9rem, 1.5vw, 1.125rem);
-  }
-
-  .glass {
-    background: rgba(30, 41, 59, 0.55);
-    border: 1px solid var(--color-border);
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
-  }
-
-  .about-lead,
-  .about-body {
-    font-size: 1.05rem;
-    line-height: 1.75;
-    color: var(--color-text-dim);
-  }
-
-  .about-lead {
-    margin-bottom: 1.25rem;
-  }
-
-  .about-lead strong,
-  .about-body strong {
-    color: var(--color-text);
-    font-weight: 600;
-  }
-
-  @media (max-width: 768px) {
-    .about-section {
-      padding: 4rem 1.25rem 2.5rem;
-    }
-
-    .about-card {
-      padding: 1.5rem 1.25rem;
-    }
   }
 </style>

--- a/src/components/EventDetails.astro
+++ b/src/components/EventDetails.astro
@@ -1,13 +1,16 @@
 ---
-import { EVENT_DETAILS } from "../lib/constants";
+import { EVENT } from "../data/event";
 import { EVENT_AGENDA } from "../data/eventAgenda";
+import GlassCard from "./primitives/GlassCard.astro";
+import Icon from "./primitives/Icon.astro";
+import Section from "./primitives/Section.astro";
+import SectionHeader from "./primitives/SectionHeader.astro";
 
 const agendaGroup = "hackmi-agenda";
 
 const splitAgendaTabLabel = (tabLabel: string) => {
   const parts = tabLabel.split("·");
   if (parts.length < 2) return { prefix: tabLabel, date: "" };
-
   const first = parts[0] ?? "";
   return {
     prefix: `${first.trim()} ·`,
@@ -16,219 +19,136 @@ const splitAgendaTabLabel = (tabLabel: string) => {
 };
 ---
 
-<section
-  class="event-details"
-  id="event-details"
-  aria-labelledby="event-heading"
->
-  <div class="container">
-    <h2 id="event-heading" class="section-title">Event details</h2>
-    <p class="section-subtitle">
-      Save the window—exact schedule and venue will be posted as we finalize
-      logistics.
-    </p>
+<Section id="event-details" labelledBy="event-heading" padding="compact">
+  <SectionHeader
+    id="event-heading"
+    title="Event details"
+    subtitle="Save the window—exact schedule and venue will be posted as we finalize logistics."
+  />
 
-    <div class="detail-grid">
-      <article class="detail-card glass" id="dates">
-        <div class="detail-card-heading">
-          <div class="detail-icon" aria-hidden="true">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="22"
-              height="22"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              ><rect x="3" y="4" width="18" height="18" rx="2" ry="2"
-              ></rect><line x1="16" y1="2" x2="16" y2="6"></line><line
-                x1="8"
-                y1="2"
-                x2="8"
-                y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg
-            >
-          </div>
-          <h3 class="detail-title">Dates</h3>
+  <div class="detail-grid">
+    <GlassCard interactive id="dates" class="detail-card">
+      <div class="detail-card-heading">
+        <div class="detail-icon" aria-hidden="true">
+          <Icon name="calendar" size={22} />
         </div>
-        <p class="detail-highlight">{EVENT_DETAILS.DATE}</p>
-        <p class="detail-lede">
-          Three days in Detroit—switch tabs for the draft agenda (times subject
-          to change).
-        </p>
+        <h3 class="detail-title">Dates</h3>
+      </div>
+      <p class="detail-highlight">{EVENT.date}</p>
+      <p class="detail-lede">
+        Three days in Detroit—switch tabs for the draft agenda (times subject to
+        change).
+      </p>
 
-        <div class="agenda">
-          {
-            EVENT_AGENDA.map((day, i) => (
-              <input
-                type="radio"
-                class="agenda-state"
-                name={agendaGroup}
-                id={`${agendaGroup}-${day.id}`}
-                checked={i === 0}
-              />
-            ))
-          }
-          <ul class="agenda-tablist" aria-label="Schedule by day">
-            {
-              EVENT_AGENDA.map((day) => (
-                <li class="agenda-tab-item">
-                  <label class="agenda-tab" for={`${agendaGroup}-${day.id}`}>
-                    {(() => {
-                      const { prefix, date } = splitAgendaTabLabel(
-                        day.tabLabel,
-                      );
-                      return date ? (
-                        <>
-                          <span class="agenda-tab-prefix">{prefix}</span>{" "}
-                          <span class="agenda-tab-date">{date}</span>
-                        </>
-                      ) : (
-                        prefix
-                      );
-                    })()}
-                  </label>
-                </li>
-              ))
-            }
-          </ul>
+      <div class="agenda">
+        {
+          EVENT_AGENDA.map((day, i) => (
+            <input
+              type="radio"
+              class="agenda-state visually-hidden"
+              name={agendaGroup}
+              id={`${agendaGroup}-${day.id}`}
+              checked={i === 0}
+            />
+          ))
+        }
+        <ul class="agenda-tablist" aria-label="Schedule by day">
           {
             EVENT_AGENDA.map((day) => (
-              <div
-                class={`agenda-panel agenda-panel--${day.id}`}
-                id={`${agendaGroup}-panel-${day.id}`}
-                aria-label={day.dayTitle ?? day.tabLabel}
-              >
-                {day.dayTitle && <p class="agenda-day-title">{day.dayTitle}</p>}
-                <ul class="agenda-slots">
-                  {day.slots.map((slot) => (
-                    <li class="agenda-slot">
-                      <span class="agenda-time">{slot.time}</span>
-                      <div class="agenda-slot-body">
-                        <span class="agenda-slot-title">{slot.title}</span>
-                        {slot.detail && (
-                          <span class="agenda-slot-detail">{slot.detail}</span>
-                        )}
-                      </div>
-                    </li>
-                  ))}
-                </ul>
-              </div>
+              <li class="agenda-tab-item">
+                <label class="agenda-tab" for={`${agendaGroup}-${day.id}`}>
+                  {(() => {
+                    const { prefix, date } = splitAgendaTabLabel(day.tabLabel);
+                    return date ? (
+                      <>
+                        <span class="agenda-tab-prefix">{prefix}</span>{" "}
+                        <span class="agenda-tab-date">{date}</span>
+                      </>
+                    ) : (
+                      prefix
+                    );
+                  })()}
+                </label>
+              </li>
             ))
           }
-        </div>
-
-        <p class="detail-copy detail-copy--after-agenda">
-          Subscribe via registration for final kickoff, judging, and showcase
-          times.
-        </p>
-      </article>
-
-      <article class="detail-card glass" id="location">
-        <div class="detail-card-heading">
-          <div class="detail-icon" aria-hidden="true">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="22"
-              height="22"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              ><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"
-              ></path><circle cx="12" cy="10" r="3"></circle></svg
+        </ul>
+        {
+          EVENT_AGENDA.map((day) => (
+            <div
+              class={`agenda-panel agenda-panel--${day.id}`}
+              id={`${agendaGroup}-panel-${day.id}`}
+              aria-label={day.dayTitle ?? day.tabLabel}
             >
-          </div>
-          <h3 class="detail-title">Location</h3>
+              {day.dayTitle && <p class="agenda-day-title">{day.dayTitle}</p>}
+              <ul class="agenda-slots">
+                {day.slots.map((slot) => (
+                  <li class="agenda-slot">
+                    <span class="agenda-time">{slot.time}</span>
+                    <div class="agenda-slot-body">
+                      <span class="agenda-slot-title">{slot.title}</span>
+                      {slot.detail && (
+                        <span class="agenda-slot-detail">{slot.detail}</span>
+                      )}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))
+        }
+      </div>
+
+      <p class="detail-copy detail-copy--after-agenda">
+        Subscribe via registration for final kickoff, judging, and showcase
+        times.
+      </p>
+    </GlassCard>
+
+    <GlassCard interactive id="location" class="detail-card">
+      <div class="detail-card-heading">
+        <div class="detail-icon" aria-hidden="true">
+          <Icon name="map-pin" size={22} />
         </div>
-        <p class="detail-highlight">
-          <a
-            href={EVENT_DETAILS.LOCATION_URL}
-            class="location-map-link"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label={`Open ${EVENT_DETAILS.LOCATION} in maps`}
-          >
-            {EVENT_DETAILS.LOCATION}
-          </a>
-        </p>
-        <div class="location-map-wrap" role="region" aria-label="Map of venue">
-          <iframe
-            class="location-map-embed"
-            title={`Google Map: ${EVENT_DETAILS.LOCATION}`}
-            src={EVENT_DETAILS.LOCATION_MAP_EMBED_URL}
-            loading="lazy"
-            referrerpolicy="no-referrer-when-downgrade"
-            allowfullscreen></iframe>
-        </div>
-        <p class="detail-copy">
-          HackMI is rooted in Detroit’s growing innovation corridor — accessible
-          to students across Southeast Michigan and visitors flying into DTW.
-          Venue and transit notes will be shared with registered participants.
-        </p>
-      </article>
-    </div>
+        <h3 class="detail-title">Location</h3>
+      </div>
+      <p class="detail-highlight">
+        <a
+          href={EVENT.locationUrl}
+          class="location-map-link"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label={`Open ${EVENT.location} in maps`}
+        >
+          {EVENT.location}
+        </a>
+      </p>
+      <div class="location-map-wrap" role="region" aria-label="Map of venue">
+        <iframe
+          class="location-map-embed"
+          title={`Google Map: ${EVENT.location}`}
+          src={EVENT.locationMapEmbedUrl}
+          loading="lazy"
+          referrerpolicy="no-referrer-when-downgrade"
+          allowfullscreen></iframe>
+      </div>
+      <p class="detail-copy">
+        HackMI is rooted in Detroit's growing innovation corridor — accessible
+        to students across Southeast Michigan and visitors flying into DTW.
+        Venue and transit notes will be shared with registered participants.
+      </p>
+    </GlassCard>
   </div>
-</section>
+</Section>
 
 <style>
-  .event-details {
-    padding: 4rem 2rem;
-    position: relative;
-  }
-
-  .container {
-    max-width: 1200px;
-    margin: 0 auto;
-  }
-
-  .section-title {
-    font-family: var(--font-heading);
-    font-size: clamp(2rem, 5vw, 3rem);
-    font-weight: 700;
-    text-align: center;
-    margin-bottom: 0.75rem;
-    color: var(--color-accent-green);
-  }
-
-  .section-subtitle {
-    text-align: center;
-    color: var(--color-text-dim);
-    font-size: 1.1rem;
-    margin-bottom: 2.5rem;
-    max-width: 720px;
-    margin-left: auto;
-    margin-right: auto;
-  }
-
   .detail-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
     gap: 1.5rem;
   }
 
-  .detail-card {
-    padding: 2rem;
-    border-radius: 1rem;
-    transition:
-      border-color 0.2s ease,
-      box-shadow 0.2s ease;
-  }
-
-  .glass {
-    background: rgba(30, 41, 59, 0.55);
-    border: 1px solid var(--color-border);
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
-  }
-
-  .detail-card:hover {
-    border-color: rgba(59, 130, 246, 0.35);
-    box-shadow: 0 12px 40px rgba(59, 130, 246, 0.1);
-  }
+  /* .detail-card padding is in global.css (cross-component override) */
 
   .detail-card-heading {
     display: flex;
@@ -244,8 +164,8 @@ const splitAgendaTabLabel = (tabLabel: string) => {
     display: flex;
     align-items: center;
     justify-content: center;
-    border-radius: 0.75rem;
-    background: rgba(59, 130, 246, 0.12);
+    border-radius: var(--radius-md);
+    background: rgb(59 130 246 / 12%);
     color: var(--color-primary);
   }
 
@@ -254,7 +174,6 @@ const splitAgendaTabLabel = (tabLabel: string) => {
   }
 
   .detail-title {
-    font-family: var(--font-heading);
     font-size: 1.125rem;
     font-weight: 600;
     color: var(--color-text);
@@ -269,30 +188,17 @@ const splitAgendaTabLabel = (tabLabel: string) => {
   }
 
   .detail-lede {
-    font-size: 0.95rem;
+    font-size: clamp(0.9rem, 1.5vw, 1.125rem);
     color: var(--color-text-dim);
     margin-bottom: 1rem;
     line-height: 1.65;
-    font-size: clamp(0.9rem, 1.5vw, 1.125rem);
   }
+
+  /* ---- Agenda tabs (CSS-only radio) ---- */
 
   .agenda {
     position: relative;
     margin-bottom: 1rem;
-    line-height: 1.65;
-    font-size: clamp(0.9rem, 1.5vw, 1.125rem);
-  }
-
-  .agenda-state {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border: 0;
     line-height: 1.65;
     font-size: clamp(0.9rem, 1.5vw, 1.125rem);
   }
@@ -304,8 +210,6 @@ const splitAgendaTabLabel = (tabLabel: string) => {
     margin: 0 0 0.75rem;
     padding: 0;
     list-style: none;
-    line-height: 1.65;
-    font-size: clamp(0.9rem, 1.5vw, 1.125rem);
   }
 
   .agenda-tab-item {
@@ -313,8 +217,6 @@ const splitAgendaTabLabel = (tabLabel: string) => {
     min-width: 0;
     margin: 0;
     padding: 0;
-    line-height: 1.65;
-    font-size: clamp(0.9rem, 1.5vw, 1.125rem);
     text-transform: uppercase;
   }
 
@@ -322,21 +224,19 @@ const splitAgendaTabLabel = (tabLabel: string) => {
     display: block;
     width: 100%;
     text-align: center;
-    padding: 0.5rem 0.5rem;
-    font-size: 0.75rem;
+    padding: 0.5rem;
+    font-size: 0.9rem;
     font-weight: 600;
     font-family: var(--font-body);
     color: #000;
     background: var(--color-accent-orange);
     border: 3px solid var(--color-accent-orange-hover);
-    border-radius: 0.5rem;
+    border-radius: var(--radius-sm);
     cursor: pointer;
     transition:
-      color 0.2s ease,
-      border-color 0.2s ease,
-      background-color 0.2s ease;
-    line-height: 1.65;
-    font-size: clamp(0.9rem, 1.5vw, 1.125rem);
+      color var(--duration-fast) ease,
+      border-color var(--duration-fast) ease,
+      background-color var(--duration-fast) ease;
     text-transform: uppercase;
   }
 
@@ -344,27 +244,9 @@ const splitAgendaTabLabel = (tabLabel: string) => {
     white-space: nowrap;
   }
 
-  @media (min-width: 400px) {
-    .agenda-tab {
-      font-size: 0.8rem;
-      padding: 0.5rem 0.65rem;
-    }
-  }
-
   .agenda-tab:hover {
     color: #000;
     border-color: var(--color-accent-orange-hover);
-  }
-
-  @keyframes agenda-panel-reveal {
-    from {
-      opacity: 0;
-      transform: translateY(0.5rem);
-    }
-    to {
-      opacity: 1;
-      transform: translateY(0);
-    }
   }
 
   .agenda-panel {
@@ -373,46 +255,34 @@ const splitAgendaTabLabel = (tabLabel: string) => {
   }
 
   /*
-   * Radio/tab panel visibility: Astro scoped CSS rewrites class selectors and breaks
-   * `#id:checked ~ .sibling` — use :global() for the ID + sibling chain.
+   * Radio/tab panel visibility: Astro scoped CSS rewrites class selectors —
+   * use :global() for ID + sibling chains.
    */
-  .event-details
-    :global(
-      #hackmi-agenda-day-1:checked
-        ~ .agenda-tablist
-        .agenda-tab[for="hackmi-agenda-day-1"]
-    ),
-  .event-details
-    :global(
-      #hackmi-agenda-day-2:checked
-        ~ .agenda-tablist
-        .agenda-tab[for="hackmi-agenda-day-2"]
-    ),
-  .event-details
-    :global(
-      #hackmi-agenda-day-3:checked
-        ~ .agenda-tablist
-        .agenda-tab[for="hackmi-agenda-day-3"]
-    ) {
+  :global(
+    #hackmi-agenda-day-1:checked
+      ~ .agenda-tablist
+      .agenda-tab[for="hackmi-agenda-day-1"]
+  ),
+  :global(
+    #hackmi-agenda-day-2:checked
+      ~ .agenda-tablist
+      .agenda-tab[for="hackmi-agenda-day-2"]
+  ),
+  :global(
+    #hackmi-agenda-day-3:checked
+      ~ .agenda-tablist
+      .agenda-tab[for="hackmi-agenda-day-3"]
+  ) {
     color: white;
-    background: rgba(59, 130, 246, 0.25);
+    background: rgb(59 130 246 / 25%);
     border-color: var(--color-primary);
   }
 
-  .event-details :global(#hackmi-agenda-day-1:checked ~ .agenda-panel--day-1),
-  .event-details :global(#hackmi-agenda-day-2:checked ~ .agenda-panel--day-2),
-  .event-details :global(#hackmi-agenda-day-3:checked ~ .agenda-panel--day-3) {
+  :global(#hackmi-agenda-day-1:checked ~ .agenda-panel--day-1),
+  :global(#hackmi-agenda-day-2:checked ~ .agenda-panel--day-2),
+  :global(#hackmi-agenda-day-3:checked ~ .agenda-panel--day-3) {
     display: block;
-    animation: agenda-panel-reveal 0.4s ease-out both;
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .event-details :global(#hackmi-agenda-day-1:checked ~ .agenda-panel--day-1),
-    .event-details :global(#hackmi-agenda-day-2:checked ~ .agenda-panel--day-2),
-    .event-details
-      :global(#hackmi-agenda-day-3:checked ~ .agenda-panel--day-3) {
-      animation: none;
-    }
+    animation: panel-reveal 0.4s var(--ease-out) both;
   }
 
   .agenda-day-title {
@@ -468,14 +338,16 @@ const splitAgendaTabLabel = (tabLabel: string) => {
     margin-top: 0.25rem;
   }
 
+  /* ---- Location ---- */
+
   .location-map-link {
     color: inherit;
     text-decoration: underline;
-    text-decoration-color: rgba(59, 130, 246, 0.45);
+    text-decoration-color: rgb(59 130 246 / 45%);
     text-underline-offset: 3px;
     transition:
-      color 0.3s ease,
-      text-decoration-color 0.3s ease;
+      color var(--duration-base) ease,
+      text-decoration-color var(--duration-base) ease;
   }
 
   .location-map-link:hover {
@@ -490,11 +362,11 @@ const splitAgendaTabLabel = (tabLabel: string) => {
   }
 
   .location-map-wrap {
-    margin: 1rem 0 1rem;
+    margin: 1rem 0;
     border-radius: 0.65rem;
     overflow: hidden;
     border: 1px solid var(--color-border);
-    background: rgba(15, 23, 42, 0.5);
+    background: rgb(15 23 42 / 50%);
     aspect-ratio: 16 / 10;
     min-height: 160px;
   }
@@ -507,15 +379,8 @@ const splitAgendaTabLabel = (tabLabel: string) => {
   }
 
   .detail-copy {
-    font-size: 0.98rem;
-    line-height: 1.65;
     font-size: clamp(0.9rem, 1.5vw, 1.125rem);
+    line-height: 1.65;
     color: var(--color-text-dim);
-  }
-
-  @media (max-width: 768px) {
-    .event-details {
-      padding: 3rem 1.25rem;
-    }
   }
 </style>

--- a/src/components/FinalAgenticCTA.astro
+++ b/src/components/FinalAgenticCTA.astro
@@ -1,5 +1,6 @@
 ---
-import { IBM_AGENTIC_CAMPAIGN_URL } from "../lib/constants";
+import Button from "./primitives/Button.astro";
+import { EVENT_URLS } from "../data/event";
 ---
 
 <section class="final-cta" id="agentic" aria-labelledby="final-cta-heading">
@@ -12,14 +13,9 @@ import { IBM_AGENTIC_CAMPAIGN_URL } from "../lib/constants";
       Continue your HackMI journey on the IBM Agentic experience: explore
       tooling, resources, and registration paths in one place.
     </p>
-    <a
-      href={IBM_AGENTIC_CAMPAIGN_URL}
-      class="btn btn-mega"
-      target="_blank"
-      rel="noopener noreferrer"
-    >
+    <Button href={EVENT_URLS.hackerRegistration} variant="mega">
       Go to IBM Agentic
-    </a>
+    </Button>
   </div>
 </section>
 
@@ -27,15 +23,15 @@ import { IBM_AGENTIC_CAMPAIGN_URL } from "../lib/constants";
   .final-cta {
     margin: 2rem 1.5rem 4rem;
     padding: clamp(2.5rem, 6vw, 4rem) clamp(1.5rem, 4vw, 3rem);
-    border-radius: 1.25rem;
+    border-radius: var(--radius-xl);
     background: linear-gradient(
       135deg,
-      rgba(59, 130, 246, 0.25) 0%,
-      rgba(139, 92, 246, 0.35) 50%,
-      rgba(236, 72, 153, 0.2) 100%
+      rgb(59 130 246 / 25%) 0%,
+      rgb(139 92 246 / 35%) 50%,
+      rgb(236 72 153 / 20%) 100%
     );
-    border: 1px solid rgba(148, 163, 184, 0.35);
-    box-shadow: 0 24px 80px rgba(0, 0, 0, 0.45);
+    border: 1px solid rgb(148 163 184 / 35%);
+    box-shadow: 0 24px 80px rgb(0 0 0 / 45%);
     text-align: center;
     max-width: 960px;
     margin-left: auto;
@@ -58,7 +54,6 @@ import { IBM_AGENTIC_CAMPAIGN_URL } from "../lib/constants";
   }
 
   .headline {
-    font-family: var(--font-heading);
     font-size: clamp(1.75rem, 4vw, 2.5rem);
     font-weight: 700;
     color: var(--color-text);
@@ -73,38 +68,9 @@ import { IBM_AGENTIC_CAMPAIGN_URL } from "../lib/constants";
     margin-bottom: 1.75rem;
   }
 
-  .btn-mega {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    padding: 1rem 2rem;
-    font-size: 1.05rem;
-    font-weight: 700;
-    font-family: var(--font-body);
-    border-radius: 0.5rem;
-    text-decoration: none;
-    color: #0f172a;
-    background: #f8fafc;
-    border: none;
-    cursor: pointer;
-    transition:
-      transform 0.2s ease,
-      box-shadow 0.2s ease;
-    box-shadow: 0 8px 30px rgba(0, 0, 0, 0.25);
-  }
-
-  .btn-mega:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.35);
-  }
-
-  @media (max-width: 768px) {
+  @media (max-width: 48rem) {
     .final-cta {
       margin: 1.5rem 1rem 3rem;
-    }
-
-    .btn-mega {
-      width: 100%;
     }
   }
 </style>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,6 +1,9 @@
 ---
 import { footerSponsorLogos, publicAssetUrl } from "../data/siteLogos";
-import { EVENT_DETAILS } from "../lib/constants";
+import { EVENT } from "../data/event";
+import { SECTION_ANCHORS, withBase } from "../data/nav";
+import { SOCIAL_LINKS } from "../data/socials";
+import MaybeLink from "./primitives/MaybeLink.astro";
 
 const base = import.meta.env.BASE_URL;
 const sponsors = footerSponsorLogos;
@@ -16,32 +19,15 @@ const currentYear = new Date().getFullYear();
           <ul class="sponsor-strip-logos" role="list">
             {sponsors.map((logo) => (
               <li>
-                {logo.href ? (
-                  <a
-                    href={logo.href}
-                    class="sponsor-strip-link"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <img
-                      src={publicAssetUrl(base, logo.src)}
-                      alt={logo.alt}
-                      class="sponsor-strip-img"
-                      loading="lazy"
-                      decoding="async"
-                    />
-                  </a>
-                ) : (
-                  <span class="sponsor-strip-wrap">
-                    <img
-                      src={publicAssetUrl(base, logo.src)}
-                      alt={logo.alt}
-                      class="sponsor-strip-img"
-                      loading="lazy"
-                      decoding="async"
-                    />
-                  </span>
-                )}
+                <MaybeLink href={logo.href ?? null} class="sponsor-strip-link">
+                  <img
+                    src={publicAssetUrl(base, logo.src)}
+                    alt={logo.alt}
+                    class="sponsor-strip-img"
+                    loading="lazy"
+                    decoding="async"
+                  />
+                </MaybeLink>
               </li>
             ))}
           </ul>
@@ -55,52 +41,44 @@ const currentYear = new Date().getFullYear();
       <div class="footer-grid">
         <div class="footer-info">
           <h3 class="footer-logo">HACKMI</h3>
-          <p class="footer-tagline">
-            Building the future of Michigan's tech corridor.
-          </p>
+          <p class="footer-tagline">{EVENT.tagline}</p>
           <p class="footer-event-details">
-            {EVENT_DETAILS.LOCATION}<br />
-            {EVENT_DETAILS.DATE}
+            {EVENT.location}<br />
+            {EVENT.date}
           </p>
         </div>
 
         <div class="footer-links">
           <h4 class="footer-title">Navigation</h4>
           <ul>
-            <li><a href={`${base}#about`}>About</a></li>
-            <li><a href={`${base}#sponsors`}>Sponsors</a></li>
-            <li><a href={`${base}#event-details`}>Details</a></li>
-            <li><a href={`${base}#logistics`}>Logistics</a></li>
+            {
+              SECTION_ANCHORS.map((a) => (
+                <li>
+                  <a href={withBase(base, a.href)}>{a.footer}</a>
+                </li>
+              ))
+            }
           </ul>
         </div>
 
         <div class="footer-social">
           <h4 class="footer-title">Connect</h4>
           <ul>
-            <li>
-              <a
-                href="https://www.linkedin.com/company/compass-detroit/"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                LinkedIn
-              </a>
-            </li>
-            <li>
-              <a
-                href="https://github.com/Compass-Detroit/"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                GitHub
-              </a>
-            </li>
+            {
+              SOCIAL_LINKS.map((s) => (
+                <li>
+                  <a href={s.href} target="_blank" rel="noopener noreferrer">
+                    {s.label}
+                  </a>
+                </li>
+              ))
+            }
           </ul>
         </div>
       </div>
 
       <div class="footer-bottom">
-        <p>&copy; {currentYear} {EVENT_DETAILS.NAME}. All rights reserved.</p>
+        <p>&copy; {currentYear} {EVENT.name}. All rights reserved.</p>
       </div>
     </div>
   </div>
@@ -110,11 +88,11 @@ const currentYear = new Date().getFullYear();
   .sponsor-strip {
     padding: 2rem 1.5rem 0;
     border-top: 1px solid var(--color-border);
-    background: rgba(15, 23, 42, 0.5);
+    background: rgb(15 23 42 / 50%);
   }
 
   .sponsor-strip-inner {
-    max-width: 1200px;
+    max-width: var(--container-max);
     margin: 0 auto;
     text-align: center;
   }
@@ -138,19 +116,15 @@ const currentYear = new Date().getFullYear();
     padding-bottom: 2rem;
   }
 
-  .sponsor-strip-link,
-  .sponsor-strip-wrap {
+  :global(.sponsor-strip-link) {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-  }
-
-  .sponsor-strip-link {
     opacity: 0.85;
-    transition: opacity 0.2s ease;
+    transition: opacity var(--duration-fast) ease;
   }
 
-  .sponsor-strip-link:hover {
+  :global(a.sponsor-strip-link:hover) {
     opacity: 1;
   }
 
@@ -162,7 +136,7 @@ const currentYear = new Date().getFullYear();
     filter: grayscale(0.15) brightness(1.05);
   }
 
-  .sponsor-strip-link:hover .sponsor-strip-img {
+  :global(a.sponsor-strip-link:hover) .sponsor-strip-img {
     filter: grayscale(0) brightness(1.1);
   }
 
@@ -173,12 +147,12 @@ const currentYear = new Date().getFullYear();
 
   .footer-main {
     padding: 4rem 2rem 3rem;
-    background: rgba(15, 23, 42, 0.9);
+    background: rgb(15 23 42 / 90%);
     border-top: 1px solid var(--color-border);
   }
 
   .container {
-    max-width: 1200px;
+    max-width: var(--container-max);
     margin: 0 auto;
   }
 
@@ -190,7 +164,6 @@ const currentYear = new Date().getFullYear();
   }
 
   .footer-logo {
-    font-family: var(--font-heading);
     font-size: 1.5rem;
     font-weight: 700;
     margin-bottom: 1rem;
@@ -231,7 +204,7 @@ const currentYear = new Date().getFullYear();
   .footer-social a {
     color: var(--color-text-dim);
     text-decoration: none;
-    transition: color 0.2s ease;
+    transition: color var(--duration-fast) ease;
   }
 
   .footer-links a:hover,
@@ -241,13 +214,13 @@ const currentYear = new Date().getFullYear();
 
   .footer-bottom {
     padding-top: 2rem;
-    border-top: 1px solid rgba(255, 255, 255, 0.05);
+    border-top: 1px solid rgb(255 255 255 / 5%);
     text-align: center;
     color: var(--color-text-dim);
     font-size: 0.9rem;
   }
 
-  @media (max-width: 768px) {
+  @media (max-width: 48rem) {
     .footer-grid {
       grid-template-columns: 1fr;
       gap: 3rem;

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -1,5 +1,7 @@
 ---
-import { EXTERNAL_URLS } from "../lib/constants";
+import Button from "./primitives/Button.astro";
+import Icon from "./primitives/Icon.astro";
+import { EVENT_URLS } from "../data/event";
 
 const base = import.meta.env.BASE_URL;
 ---
@@ -15,35 +17,23 @@ const base = import.meta.env.BASE_URL;
     <p class="hero-subtitle">REGISTRATION IS NOW OPEN</p>
 
     <div class="hero-buttons">
-      <a
-        href={EXTERNAL_URLS.HACKER_REGISTRATION}
-        class="btn btn-primary"
-        target="_blank"
-        rel="noopener noreferrer"
+      <Button
+        href={EVENT_URLS.hackerRegistration}
+        variant="primary"
+        accent="block-on-mobile"
       >
         <span>Register Now</span>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="20"
-          height="20"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-        >
-          <line x1="5" y1="12" x2="19" y2="12"></line>
-          <polyline points="12 5 19 12 12 19"></polyline>
-        </svg>
-      </a>
-      <a
-        href={EXTERNAL_URLS.SPONSOR_INQUIRY}
-        class="btn btn-secondary hero-btn-sponsor"
+        <Icon name="arrow-right" size={20} />
+      </Button>
+      <Button
+        href={EVENT_URLS.sponsorInquiry}
+        variant="ghost"
+        accent={["sponsor-glow", "block-on-mobile"]}
       >
         <span>Become a Sponsor</span>
-      </a>
+      </Button>
     </div>
+
     <p class="hero-description">
       Michigan was built by innovators—and it's time to innovate again. Build an
       AI + open-source proof of concept that modernizes a Michigan industry.
@@ -79,7 +69,7 @@ const base = import.meta.env.BASE_URL;
     text-align: center;
     z-index: 10;
     max-width: 800px;
-    animation: fadeInUp 0.8s ease-out;
+    animation: fade-in-up 0.8s var(--ease-out);
   }
 
   .greeting {
@@ -92,7 +82,6 @@ const base = import.meta.env.BASE_URL;
   }
 
   .hero-title {
-    font-family: var(--font-heading);
     font-size: clamp(3rem, 12vw, 7rem);
     font-weight: 700;
     margin-bottom: 1rem;
@@ -111,17 +100,7 @@ const base = import.meta.env.BASE_URL;
     background-clip: text;
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
-    animation: gradientFlow 4s ease infinite;
-  }
-
-  @keyframes gradientFlow {
-    0%,
-    100% {
-      background-position: 0% 50%;
-    }
-    50% {
-      background-position: 100% 50%;
-    }
+    animation: text-shimmer 4s ease infinite;
   }
 
   .hero-subtitle {
@@ -151,70 +130,6 @@ const base = import.meta.env.BASE_URL;
     margin-block: 3rem;
   }
 
-  .btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.875rem 1.75rem;
-    font-size: 1rem;
-    font-weight: 600;
-    font-family: var(--font-body);
-    border: none;
-    border-radius: 0.5rem;
-    cursor: pointer;
-    text-decoration: none;
-    transition: all 0.2s ease;
-  }
-
-  .btn-primary {
-    background: var(--color-accent-orange);
-    color: #000;
-    box-shadow: 0 4px 14px rgba(59, 130, 246, 0.4);
-    text-transform: uppercase;
-  }
-
-  .btn-primary:hover {
-    background: var(--color-accent-orange-hover);
-    box-shadow: 0 6px 20px rgba(59, 130, 246, 0.5);
-  }
-
-  .btn-primary svg {
-    transition: transform 0.2s ease;
-  }
-
-  .btn-primary:hover svg {
-    transform: translateX(4px);
-  }
-
-  .btn-secondary {
-    background: transparent;
-    color: var(--color-text);
-    border: 3px solid var(--color-border);
-    text-transform: uppercase;
-  }
-
-  .btn-secondary:hover {
-    background: rgba(59, 130, 246, 0.1);
-    border-color: var(--color-primary);
-  }
-
-  .hero-btn-sponsor {
-    border-color: rgba(251, 191, 36, 0.55);
-    box-shadow:
-      0 0 0 1px rgba(251, 191, 36, 0.12),
-      0 0 20px rgba(251, 191, 36, 0.35),
-      0 0 44px rgba(245, 158, 11, 0.22);
-  }
-
-  .hero-btn-sponsor:hover {
-    background: rgba(251, 191, 36, 0.08);
-    border-color: rgba(252, 211, 77, 0.85);
-    box-shadow:
-      0 0 0 1px rgba(252, 211, 77, 0.2),
-      0 0 26px rgba(251, 191, 36, 0.5),
-      0 0 52px rgba(245, 158, 11, 0.32);
-  }
-
   .hero-chips {
     display: flex;
     gap: 0.75rem;
@@ -224,12 +139,14 @@ const base = import.meta.env.BASE_URL;
 
   .hero-chip {
     padding: 0.5rem 1rem;
-    background: rgba(59, 130, 246, 0.1);
+    background: rgb(59 130 246 / 10%);
     border: 3px solid var(--color-accent-orange);
-    border-radius: 2rem;
+    border-radius: var(--radius-pill);
     font-size: 0.875rem;
     color: var(--color-text-dim);
-    transition: all 0.2s ease;
+    transition:
+      border-color var(--duration-fast) ease,
+      color var(--duration-fast) ease;
     text-decoration: none;
     text-transform: uppercase;
   }
@@ -262,7 +179,7 @@ const base = import.meta.env.BASE_URL;
     background: var(--color-primary-button);
     top: 10%;
     left: 10%;
-    animation: float 8s ease-in-out infinite;
+    animation: float-drift 8s ease-in-out infinite;
   }
 
   .glow-2 {
@@ -271,44 +188,10 @@ const base = import.meta.env.BASE_URL;
     background: var(--color-accent-purple);
     bottom: 20%;
     right: 10%;
-    animation: float 6s ease-in-out infinite reverse;
+    animation: float-drift 6s ease-in-out infinite reverse;
   }
 
-  @keyframes fadeInUp {
-    from {
-      opacity: 0;
-      transform: translateY(30px);
-    }
-    to {
-      opacity: 1;
-      transform: translateY(0);
-    }
-  }
-
-  @keyframes float {
-    0%,
-    100% {
-      transform: translate(0, 0);
-    }
-    50% {
-      transform: translate(20px, -20px);
-    }
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .title-text {
-      animation: none;
-    }
-    .glow-1,
-    .glow-2 {
-      animation: none;
-    }
-    .hero-content {
-      animation: none;
-    }
-  }
-
-  @media (max-width: 768px) {
+  @media (max-width: 48rem) {
     .hero {
       padding-top: calc(var(--nav-height) + 3rem);
     }
@@ -316,12 +199,6 @@ const base = import.meta.env.BASE_URL;
     .hero-buttons {
       flex-direction: column;
       align-items: center;
-    }
-
-    .btn {
-      width: 100%;
-      max-width: 280px;
-      justify-content: center;
     }
   }
 </style>

--- a/src/components/LogisticsSection.astro
+++ b/src/components/LogisticsSection.astro
@@ -1,146 +1,45 @@
 ---
-// Rules, prizes, judges, criteria — placeholder content until handbook is ready
+import { LOGISTICS_CARDS } from "../data/logistics";
+import GlassCard from "./primitives/GlassCard.astro";
+import Section from "./primitives/Section.astro";
+import SectionHeader from "./primitives/SectionHeader.astro";
 ---
 
-<section class="logistics" id="logistics" aria-labelledby="logistics-heading">
-  <div class="container">
-    <h2 id="logistics-heading" class="section-title">Logistics for hackers</h2>
-    <p class="section-subtitle">
-      What to expect on the ground—full details will live in the participant
-      guide.
-    </p>
+<Section
+  id="logistics"
+  labelledBy="logistics-heading"
+  padding="compact"
+  style="padding-bottom: 5rem;"
+>
+  <SectionHeader
+    id="logistics-heading"
+    title="Logistics for hackers"
+    subtitle="What to expect on the ground—full details will live in the participant guide."
+  />
 
-    <div class="logistics-grid">
-      <article class="log-card glass" id="rules">
-        <h3 class="log-title">Rules</h3>
-        <ul class="log-list">
-          <li>
-            <strong>Team Size:</strong> Participate individually or in teams of up
-            to 5 people.
-          </li>
-          <li>
-            <strong>Eligibility:</strong> Must be 18 years or older (or age of emancipation
-            in your jurisdiction).
-          </li>
-          <li>
-            <strong>Technology Requirement:</strong> All submissions must use IBM
-            watsonx technology (watsonx.ai, watsonx.data, or IBM Granite models) or
-            other AI and Open Source technologies.
-          </li>
-          <li>
-            <strong>Originality:</strong> Projects must be original work created during
-            the hackathon period (May 15-17, 2026).
-          </li>
-          <li>
-            <strong>Deliverables:</strong> Each submission must include a video demonstration,
-            written problem/solution statements, a statement on technology utilized,
-            and optionally a working code repository.
-          </li>
-          <li>
-            Our goal is a fair, inclusive, and safe event for everyone. Full
-            code of conduct and detailed rules available in the official rules
-            document.
-          </li>
-        </ul>
-      </article>
-      <article class="log-card glass" id="prizes">
-        <h3 class="log-title">Prizes</h3>
-        <ul class="log-list">
-          <li>
-            Top teams will receive cash prizes, IBM and partner swag, mentorship
-            opportunities with Michigan tech leaders, and exclusive access to
-            IBM watsonx resources to continue developing their solutions.
-          </li>
-          <li>
-            Winners will also be featured in Hack Michigan media and invited to
-            present at future Michigan innovation events.
-          </li>
-          <li>
-            Full prize details and tiers will be announced at the opening
-            ceremony on May 15, 2026.
-          </li>
-        </ul>
-      </article>
-      <article class="log-card glass" id="judges">
-        <h3 class="log-title">Judges</h3>
-        <ul class="log-list">
-          <li>
-            Judges from industry and academia will join us in Detroit. Names and
-            backgrounds will be listed once the panel is confirmed.
-          </li>
-        </ul>
-      </article>
-      <article class="log-card glass" id="judging-criteria">
-        <h3 class="log-title">Judging criteria</h3>
-        <p class="log-copy">
-          Each submission will be scored on the following criteria (maximum 25
-          points total):
-        </p>
-        <ul class="log-list">
-          <li>
-            <strong>Completeness and Feasibility (5 points)</strong> — Is the solution
-            complete and realistic?
-          </li>
-          <li>
-            <strong>Effectiveness and Efficiency (5 points)</strong> — Does it solve
-            the problem well?
-          </li>
-          <li>
-            <strong>Design and Usability (5 points)</strong> — Is it well-designed
-            and user-friendly?
-          </li>
-          <li>
-            <strong>Creativity and Innovation (5 points)</strong> — Is it innovative
-            and creative?
-          </li>
-          <li>
-            <strong>Michigan Impact (5 points)</strong> — Does it keep value, jobs,
-            and opportunity in Michigan?
-          </li>
-          <li>
-            <strong>Your solution should also demonstrate:</strong> practical application
-            solving a real Michigan challenge, clear business value, implementability
-            as a working proof-of-concept, and strong storytelling that positions
-            Michigan as a technology innovator.
-          </li>
-          <li>
-            <strong>Final scores</strong> will be the average of judges' scores based
-            on your submitted deliverables.
-          </li>
-        </ul>
-      </article>
-    </div>
+  <div class="logistics-grid">
+    {
+      LOGISTICS_CARDS.map((card) => (
+        <GlassCard interactive hover="violet" id={card.id} class="log-card">
+          <h3 class="log-title">{card.title}</h3>
+          {card.preamble && <p class="log-copy">{card.preamble}</p>}
+          <ul class="log-list">
+            {card.rows.map((row) => (
+              <li>
+                {row.label && <strong>{row.label}</strong>}
+                {row.text}
+              </li>
+            ))}
+          </ul>
+        </GlassCard>
+      ))
+    }
   </div>
-</section>
+</Section>
 
 <style>
-  .logistics {
-    padding: 4rem 2rem 5rem;
-    position: relative;
-  }
-
-  .container {
-    max-width: 1200px;
-    margin: 0 auto;
-  }
-
-  .section-title {
-    font-family: var(--font-heading);
-    font-size: clamp(2rem, 5vw, 3rem);
-    font-weight: 700;
-    text-align: center;
-    margin-bottom: 0.75rem;
-    color: var(--color-accent-green);
-  }
-
-  .section-subtitle {
-    text-align: center;
-    color: var(--color-text-dim);
+  :global(#logistics .section-subtitle) {
     font-size: 1.5rem;
-    margin-bottom: 2.5rem;
-    max-width: 720px;
-    margin-left: auto;
-    margin-right: auto;
   }
 
   .logistics-grid {
@@ -149,28 +48,9 @@
     gap: 1.5rem;
   }
 
-  .log-card {
-    padding: 1.75rem;
-    border-radius: 1rem;
-    transition:
-      border-color 0.2s ease,
-      box-shadow 0.2s ease;
-  }
-
-  .glass {
-    background: rgba(30, 41, 59, 0.55);
-    border: 1px solid var(--color-border);
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
-  }
-
-  .log-card:hover {
-    border-color: rgba(139, 92, 246, 0.35);
-    box-shadow: 0 12px 40px rgba(139, 92, 246, 0.08);
-  }
+  /* .log-card padding is in global.css (cross-component override) */
 
   .log-title {
-    font-family: var(--font-heading);
     font-size: 1.4rem;
     font-weight: 600;
     color: var(--color-accent-green);
@@ -194,20 +74,18 @@
     color: var(--color-accent-green);
     font-weight: 600;
   }
+
   .log-list li {
     margin-bottom: 1.2rem;
   }
 
-  @media (max-width: 1185px) {
+  @media (max-width: 74rem) {
     .logistics-grid {
       grid-template-columns: repeat(2, 1fr);
     }
   }
-  @media (max-width: 768px) {
-    .logistics {
-      padding: 3rem 1.25rem 4rem;
-    }
 
+  @media (max-width: 48rem) {
     .logistics-grid {
       grid-template-columns: 1fr;
     }

--- a/src/components/LogisticsSection.astro
+++ b/src/components/LogisticsSection.astro
@@ -27,6 +27,7 @@ import SectionHeader from "./primitives/SectionHeader.astro";
             {card.rows.map((row) => (
               <li>
                 {row.label && <strong>{row.label}</strong>}
+                {row.label && " "}
                 {row.text}
               </li>
             ))}

--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -360,19 +360,25 @@ const wordmark = "wordmark" in brand ? brand.wordmark : undefined;
       btn!.setAttribute("aria-expanded", String(open));
       btn!.setAttribute("aria-label", open ? "Close menu" : "Open menu");
       document.body.style.overflow = open ? "hidden" : "";
+
+      if (open) {
+        document.addEventListener("keydown", onEscape);
+      } else {
+        document.removeEventListener("keydown", onEscape);
+      }
+    }
+
+    function onEscape(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        setOpen(false);
+        btn!.focus();
+      }
     }
 
     btn.addEventListener("click", () => {
       const isOpen = menu.classList.contains("open");
       setOpen(!isOpen);
       if (!menu.classList.contains("open")) btn.focus();
-    });
-
-    menu.addEventListener("keydown", (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        setOpen(false);
-        btn.focus();
-      }
     });
 
     const mobileLinks = menu.querySelectorAll(

--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -1,6 +1,6 @@
 ---
 import { publicAssetUrl, siteHeaderBrand } from "../data/siteLogos";
-import { EXTERNAL_URLS } from "../lib/constants";
+import { SECTION_ANCHORS, PRIMARY_CTA, withBase } from "../data/nav";
 
 const base = import.meta.env.BASE_URL;
 const currentPath = Astro.url.pathname;
@@ -34,35 +34,35 @@ const wordmark = "wordmark" in brand ? brand.wordmark : undefined;
         >
           Home
         </a>
-        <a href={`${base}#about`} class="nav-link">About</a>
-        <a href={`${base}#sponsors`} class="nav-link">Sponsors</a>
-        <a href={`${base}#event-details`} class="nav-link">Event</a>
-        <a href={`${base}#logistics`} class="nav-link">Logistics</a>
+        {
+          SECTION_ANCHORS.map((a) => (
+            <a href={withBase(base, a.href)} class="nav-link">
+              {a.nav}
+            </a>
+          ))
+        }
         <a
-          href={EXTERNAL_URLS.HACKER_REGISTRATION}
+          href={PRIMARY_CTA.hacker.href}
           class="nav-link nav-link-external"
           target="_blank"
           rel="noopener noreferrer"
         >
-          Register
+          {PRIMARY_CTA.hacker.label}
         </a>
-        <a
-          href={EXTERNAL_URLS.SPONSOR_INQUIRY}
-          class="nav-cta"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Sponsor
+        <a href={PRIMARY_CTA.sponsor.href} class="nav-cta">
+          {PRIMARY_CTA.sponsor.label}
         </a>
       </div>
 
       <button
         class="mobile-menu-btn"
-        aria-label="Toggle menu"
+        aria-expanded="false"
+        aria-controls="mobile-menu"
+        aria-label="Open menu"
         id="mobile-menu-btn"
       >
         <svg
-          class="icon"
+          class="hamburger-icon"
           xmlns="http://www.w3.org/2000/svg"
           width="24"
           height="24"
@@ -72,6 +72,7 @@ const wordmark = "wordmark" in brand ? brand.wordmark : undefined;
           stroke-width="2"
           stroke-linecap="round"
           stroke-linejoin="round"
+          aria-hidden="true"
         >
           <line x1="3" y1="12" x2="21" y2="12"></line>
           <line x1="3" y1="6" x2="21" y2="6"></line>
@@ -81,7 +82,7 @@ const wordmark = "wordmark" in brand ? brand.wordmark : undefined;
     </div>
   </div>
 
-  <div class="mobile-menu" id="mobile-menu">
+  <div class="mobile-menu" id="mobile-menu" aria-hidden="true">
     <div class="mobile-menu-content">
       <a
         href={base}
@@ -89,25 +90,23 @@ const wordmark = "wordmark" in brand ? brand.wordmark : undefined;
       >
         Home
       </a>
-      <a href={`${base}#about`} class="mobile-nav-link">About</a>
-      <a href={`${base}#sponsors`} class="mobile-nav-link">Sponsors</a>
-      <a href={`${base}#event-details`} class="mobile-nav-link">Event</a>
-      <a href={`${base}#logistics`} class="mobile-nav-link">Logistics</a>
+      {
+        SECTION_ANCHORS.map((a) => (
+          <a href={withBase(base, a.href)} class="mobile-nav-link">
+            {a.nav}
+          </a>
+        ))
+      }
       <a
-        href={EXTERNAL_URLS.HACKER_REGISTRATION}
+        href={PRIMARY_CTA.hacker.href}
         class="mobile-nav-link"
         target="_blank"
         rel="noopener noreferrer"
       >
-        Register
+        {PRIMARY_CTA.hacker.label}
       </a>
-      <a
-        href={EXTERNAL_URLS.SPONSOR_INQUIRY}
-        class="mobile-nav-cta"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        Become a sponsor
+      <a href={PRIMARY_CTA.sponsorLong.href} class="mobile-nav-cta">
+        {PRIMARY_CTA.sponsorLong.label}
       </a>
     </div>
   </div>
@@ -121,17 +120,17 @@ const wordmark = "wordmark" in brand ? brand.wordmark : undefined;
     right: 1rem;
     z-index: 1000;
     padding: 1rem 1.5rem;
-    background: rgba(15, 23, 42, 0.85);
+    background: rgb(15 23 42 / 85%);
     backdrop-filter: blur(12px);
     -webkit-backdrop-filter: blur(12px);
     border: 1px solid var(--color-border);
-    border-radius: 1rem;
-    animation: slideDown 0.5s ease-out;
+    border-radius: var(--radius-lg);
+    animation: slide-down 0.5s var(--ease-out);
     text-transform: uppercase;
   }
 
   .nav-container {
-    max-width: 1200px;
+    max-width: var(--container-max);
     margin: 0 auto;
     display: flex;
     align-items: center;
@@ -157,7 +156,7 @@ const wordmark = "wordmark" in brand ? brand.wordmark : undefined;
     text-decoration: none;
     letter-spacing: 0.05em;
     color: var(--color-text);
-    transition: color 0.2s ease;
+    transition: color var(--duration-fast) ease;
   }
 
   .site-logo-img {
@@ -195,7 +194,7 @@ const wordmark = "wordmark" in brand ? brand.wordmark : undefined;
     font-weight: 500;
     font-size: 0.9rem;
     position: relative;
-    transition: color 0.2s ease;
+    transition: color var(--duration-fast) ease;
     cursor: pointer;
     white-space: nowrap;
   }
@@ -208,7 +207,7 @@ const wordmark = "wordmark" in brand ? brand.wordmark : undefined;
     width: 0;
     height: 2px;
     background: var(--color-accent-orange);
-    transition: width 0.2s ease;
+    transition: width var(--duration-fast) ease;
   }
 
   .nav-link:hover {
@@ -230,21 +229,21 @@ const wordmark = "wordmark" in brand ? brand.wordmark : undefined;
 
   .nav-cta {
     padding: 0.5rem 1rem;
-    border-radius: 0.5rem;
+    border-radius: var(--radius-sm);
     font-size: 0.9rem;
     font-weight: 600;
     color: #000;
     background: var(--color-accent-orange);
     text-decoration: none;
     transition:
-      background-color 0.2s ease,
-      box-shadow 0.2s ease;
+      background-color var(--duration-fast) ease,
+      box-shadow var(--duration-fast) ease;
     white-space: nowrap;
   }
 
   .nav-cta:hover {
     background: var(--color-accent-orange-hover);
-    box-shadow: 0 4px 14px rgba(59, 130, 246, 0.35);
+    box-shadow: var(--shadow-sm);
   }
 
   .mobile-menu-btn {
@@ -256,7 +255,7 @@ const wordmark = "wordmark" in brand ? brand.wordmark : undefined;
     padding: 0.5rem;
   }
 
-  .mobile-menu-btn .icon {
+  .mobile-menu-btn .hamburger-icon {
     width: 24px;
     height: 24px;
   }
@@ -268,11 +267,11 @@ const wordmark = "wordmark" in brand ? brand.wordmark : undefined;
     left: 0;
     right: 0;
     bottom: 0;
-    background: rgba(15, 23, 42, 0.98);
+    background: rgb(15 23 42 / 98%);
     z-index: 999;
     opacity: 0;
     pointer-events: none;
-    transition: opacity 0.3s ease;
+    transition: opacity var(--duration-base) ease;
   }
 
   .mobile-menu.open {
@@ -296,7 +295,7 @@ const wordmark = "wordmark" in brand ? brand.wordmark : undefined;
     font-weight: 600;
     color: var(--color-accent-orange-hover);
     text-decoration: none;
-    transition: color 0.2s ease;
+    transition: color var(--duration-fast) ease;
   }
 
   .mobile-nav-link:hover,
@@ -307,7 +306,7 @@ const wordmark = "wordmark" in brand ? brand.wordmark : undefined;
   .mobile-nav-cta {
     margin-top: 0.5rem;
     padding: 0.85rem 1.75rem;
-    border-radius: 0.5rem;
+    border-radius: var(--radius-sm);
     font-family: var(--font-heading);
     font-size: 1.25rem;
     font-weight: 700;
@@ -316,18 +315,7 @@ const wordmark = "wordmark" in brand ? brand.wordmark : undefined;
     text-decoration: none;
   }
 
-  @keyframes slideDown {
-    from {
-      transform: translateY(-100%);
-      opacity: 0;
-    }
-    to {
-      transform: translateY(0);
-      opacity: 1;
-    }
-  }
-
-  @media (max-width: 1024px) {
+  @media (max-width: 64rem) {
     .nav-links {
       gap: 0.75rem;
     }
@@ -337,7 +325,7 @@ const wordmark = "wordmark" in brand ? brand.wordmark : undefined;
     }
   }
 
-  @media (max-width: 768px) {
+  @media (max-width: 48rem) {
     .nav {
       top: 0.75rem;
       left: 0.75rem;
@@ -348,11 +336,6 @@ const wordmark = "wordmark" in brand ? brand.wordmark : undefined;
     .site-logo-img {
       height: 36px;
       max-width: 160px;
-    }
-
-    .nav-org-logo-img {
-      max-height: 22px;
-      max-width: 90px;
     }
 
     .nav-links {
@@ -367,22 +350,36 @@ const wordmark = "wordmark" in brand ? brand.wordmark : undefined;
 
 <script>
   document.addEventListener("astro:page-load", () => {
-    const mobileMenuBtn = document.getElementById("mobile-menu-btn");
-    const mobileMenu = document.getElementById("mobile-menu");
+    const btn = document.getElementById("mobile-menu-btn");
+    const menu = document.getElementById("mobile-menu");
+    if (!btn || !menu) return;
 
-    if (mobileMenuBtn && mobileMenu) {
-      mobileMenuBtn.addEventListener("click", () => {
-        mobileMenu.classList.toggle("open");
-      });
-
-      const mobileLinks = mobileMenu.querySelectorAll(
-        ".mobile-nav-link, .mobile-nav-cta",
-      );
-      mobileLinks.forEach((link) => {
-        link.addEventListener("click", () => {
-          mobileMenu.classList.remove("open");
-        });
-      });
+    function setOpen(open: boolean) {
+      menu!.classList.toggle("open", open);
+      menu!.setAttribute("aria-hidden", String(!open));
+      btn!.setAttribute("aria-expanded", String(open));
+      btn!.setAttribute("aria-label", open ? "Close menu" : "Open menu");
+      document.body.style.overflow = open ? "hidden" : "";
     }
+
+    btn.addEventListener("click", () => {
+      const isOpen = menu.classList.contains("open");
+      setOpen(!isOpen);
+      if (!menu.classList.contains("open")) btn.focus();
+    });
+
+    menu.addEventListener("keydown", (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setOpen(false);
+        btn.focus();
+      }
+    });
+
+    const mobileLinks = menu.querySelectorAll(
+      ".mobile-nav-link, .mobile-nav-cta",
+    );
+    mobileLinks.forEach((link) => {
+      link.addEventListener("click", () => setOpen(false));
+    });
   });
 </script>

--- a/src/components/SignupSection.astro
+++ b/src/components/SignupSection.astro
@@ -1,54 +1,33 @@
 ---
-import { HACKER_REGISTRATION_URL } from "../lib/constants";
+import Button from "./primitives/Button.astro";
+import GlassCard from "./primitives/GlassCard.astro";
+import Section from "./primitives/Section.astro";
+import { EVENT_URLS } from "../data/event";
 ---
 
-<section class="signup" id="signup" aria-labelledby="signup-heading">
-  <div class="container">
-    <div class="signup-card glass">
-      <h2 id="signup-heading" class="signup-title">Join the list</h2>
-      <p class="signup-copy">
-        Registration runs through our IBM Agentic campaign page—no on-site forms
-        here. Save your spot and get schedule updates as we lock venue and
-        tracks.
-      </p>
-      <a
-        href={HACKER_REGISTRATION_URL}
-        class="btn btn-primary"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        Register for Hack Michigan
-      </a>
-    </div>
-  </div>
-</section>
+<Section
+  id="signup"
+  labelledBy="signup-heading"
+  width="narrow"
+  padding="none"
+  style="padding: 0 2rem 4rem;"
+>
+  <GlassCard as="div" class="signup-card">
+    <h2 id="signup-heading" class="signup-title">Join the list</h2>
+    <p class="signup-copy">
+      Registration runs through our IBM Agentic campaign page—no on-site forms
+      here. Save your spot and get schedule updates as we lock venue and tracks.
+    </p>
+    <Button href={EVENT_URLS.hackerRegistration}>
+      Register for Hack Michigan
+    </Button>
+  </GlassCard>
+</Section>
 
 <style>
-  .signup {
-    padding: 0 2rem 4rem;
-    position: relative;
-  }
-
-  .container {
-    max-width: 720px;
-    margin: 0 auto;
-  }
-
-  .signup-card {
-    padding: 2.25rem 2rem;
-    border-radius: 1rem;
-    text-align: center;
-  }
-
-  .glass {
-    background: rgba(30, 41, 59, 0.55);
-    border: 1px solid var(--color-border);
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
-  }
+  /* .signup-card padding + text-align is in global.css (cross-component override) */
 
   .signup-title {
-    font-family: var(--font-heading);
     font-size: clamp(1.5rem, 3vw, 2rem);
     font-weight: 700;
     color: var(--color-text);
@@ -60,36 +39,5 @@ import { HACKER_REGISTRATION_URL } from "../lib/constants";
     font-size: 1.05rem;
     line-height: 1.65;
     margin-bottom: 1.5rem;
-  }
-
-  .btn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    padding: 0.9rem 1.75rem;
-    font-size: 1rem;
-    font-weight: 600;
-    font-family: var(--font-body);
-    border-radius: 0.5rem;
-    text-decoration: none;
-    transition: all 0.2s ease;
-  }
-
-  .btn-primary {
-    background: var(--color-accent-orange);
-    color: #000;
-    text-transform: uppercase;
-    box-shadow: 0 4px 14px rgba(59, 130, 246, 0.35);
-  }
-
-  .btn:hover {
-    background: var(--color-accent-orange-hover);
-    box-shadow: 0 6px 20px rgba(59, 130, 246, 0.45);
-  }
-
-  @media (max-width: 768px) {
-    .signup {
-      padding: 0 1.25rem 3rem;
-    }
   }
 </style>

--- a/src/components/SponsorCTA.astro
+++ b/src/components/SponsorCTA.astro
@@ -1,5 +1,7 @@
 ---
-import { EXTERNAL_URLS } from "../lib/constants";
+import Button from "./primitives/Button.astro";
+import GlassCard from "./primitives/GlassCard.astro";
+import { EVENT_URLS } from "../data/event";
 
 const base = import.meta.env.BASE_URL;
 ---
@@ -9,8 +11,8 @@ const base = import.meta.env.BASE_URL;
   id="sponsor-cta"
   aria-labelledby="sponsor-cta-heading"
 >
-  <div class="sponsor-cta-inner glass">
-    <p class="eyebrow">Partners &amp; supporters</p>
+  <GlassCard as="div" elevation="raised" class="sponsor-cta-inner">
+    <p class="section-eyebrow">Partners &amp; supporters</p>
     <h2 id="sponsor-cta-heading" class="headline">
       Support the Next Wave of Michigan Innovation
     </h2>
@@ -20,17 +22,12 @@ const base = import.meta.env.BASE_URL;
       Detroit.
     </p>
     <div class="actions">
-      <a
-        href={EXTERNAL_URLS.SPONSOR_INQUIRY}
-        class="btn btn-primary"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        Become a Sponsor
-      </a>
-      <a href={`${base}#event-details`} class="btn btn-ghost">Event details</a>
+      <Button href={EVENT_URLS.sponsorInquiry}> Become a Sponsor </Button>
+      <Button href={`${base}#event-details`} variant="secondary">
+        Event details
+      </Button>
     </div>
-  </div>
+  </GlassCard>
 </section>
 
 <style>
@@ -39,33 +36,15 @@ const base = import.meta.env.BASE_URL;
     position: relative;
   }
 
-  .sponsor-cta-inner {
+  .sponsor-cta :global(.sponsor-cta-inner) {
     max-width: 900px;
     margin: 0 auto;
     padding: 2.5rem 2rem;
-    border-radius: 1.25rem;
+    border-radius: 20px;
     text-align: center;
   }
 
-  .glass {
-    background: rgba(30, 41, 59, 0.65);
-    border: 1px solid var(--color-border);
-    backdrop-filter: blur(14px);
-    -webkit-backdrop-filter: blur(14px);
-    box-shadow: 0 20px 50px rgba(0, 0, 0, 0.35);
-  }
-
-  .eyebrow {
-    font-size: 0.75rem;
-    font-weight: 600;
-    letter-spacing: 0.14em;
-    text-transform: uppercase;
-    color: var(--color-primary);
-    margin-bottom: 0.75rem;
-  }
-
   .headline {
-    font-family: var(--font-heading);
     font-size: clamp(1.5rem, 4vw, 2.25rem);
     font-weight: 700;
     color: var(--color-text);
@@ -88,48 +67,12 @@ const base = import.meta.env.BASE_URL;
     justify-content: center;
   }
 
-  .btn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.5rem;
-    padding: 0.875rem 1.5rem;
-    font-size: 1rem;
-    font-weight: 600;
-    font-family: var(--font-body);
-    border-radius: 0.5rem;
-    text-decoration: none;
-    transition: all 0.2s ease;
-    border: 1px solid transparent;
-    cursor: pointer;
+  /* Override button padding to match live (14px 24px) */
+  .actions :global(.btn) {
+    padding: 14px 24px;
   }
 
-  .btn-primary {
-    background: var(--color-accent-orange);
-    color: #000;
-    text-transform: uppercase;
-
-    box-shadow: 0 4px 14px rgba(59, 130, 246, 0.35);
-  }
-
-  .btn-primary:hover {
-    background: var(--color-accent-orange-hover);
-    box-shadow: 0 6px 20px rgba(59, 130, 246, 0.45);
-  }
-
-  .btn-ghost {
-    background: transparent;
-    color: var(--color-accent-orange);
-    border: 3px solid var(--color-accent-orange);
-    text-transform: uppercase;
-  }
-
-  .btn-ghost:hover {
-    border-color: var(--color-accent-orange-hover);
-    color: var(--color-accent-orange-hover);
-  }
-
-  @media (max-width: 768px) {
+  @media (max-width: 48rem) {
     .sponsor-cta {
       padding: 0 1.25rem 1.5rem;
     }
@@ -137,10 +80,6 @@ const base = import.meta.env.BASE_URL;
     .actions {
       flex-direction: column;
       align-items: stretch;
-    }
-
-    .btn {
-      width: 100%;
     }
   }
 </style>

--- a/src/components/SponsorTier.astro
+++ b/src/components/SponsorTier.astro
@@ -1,0 +1,181 @@
+---
+/**
+ * SponsorTier - renders one tier's slot grid.
+ *
+ * A tier is a heading + a fixed number of slots. Real logos fill from the
+ * left; remaining slots render as `+` placeholders (for open inventory).
+ */
+import MaybeLink from "./primitives/MaybeLink.astro";
+import type { SponsorLogo } from "../data/sponsorLogos";
+import { publicAssetUrl } from "../data/siteLogos";
+
+interface Props {
+  heading: string;
+  headingId: string;
+  logos: readonly SponsorLogo[];
+  totalSlots: number;
+  layout: "host" | "diamond" | "gold" | "community";
+  shape: "card" | "square";
+  slotLabel: string;
+}
+
+const { heading, headingId, logos, totalSlots, layout, shape, slotLabel } =
+  Astro.props;
+
+const base = import.meta.env.BASE_URL;
+const placeholderCount = Math.max(0, totalSlots - logos.length);
+const slotShapeClass = `sponsor-slot--${shape}`;
+---
+
+<section
+  class={`sponsor-tier sponsor-tier--${layout}`}
+  aria-labelledby={headingId}
+>
+  <h3 id={headingId} class="tier-heading">{heading}</h3>
+  <ul class={`tier-slots tier-slots--${layout}`}>
+    {
+      logos.map((logo) => (
+        <li
+          class:list={[
+            "sponsor-slot",
+            slotShapeClass,
+            logo.surface === "light" && "sponsor-slot--surface-light",
+          ]}
+          aria-label={`${slotLabel} -- ${logo.alt}`}
+        >
+          <MaybeLink href={logo.href ?? null} class="sponsor-logo-link">
+            <img
+              class="sponsor-logo"
+              src={publicAssetUrl(base, logo.src)}
+              alt={logo.alt}
+              loading="lazy"
+              decoding="async"
+            />
+          </MaybeLink>
+        </li>
+      ))
+    }
+    {
+      Array.from({ length: placeholderCount }, (_, i) => i + 1).map((n) => (
+        <li
+          class:list={["sponsor-slot", slotShapeClass]}
+          aria-label={`${slotLabel} slot ${logos.length + n} of ${totalSlots} -- logo placeholder`}
+        >
+          <span class="sponsor-slot__plus" aria-hidden="true">
+            +
+          </span>
+        </li>
+      ))
+    }
+  </ul>
+</section>
+
+<style>
+  .sponsor-tier {
+    text-align: center;
+  }
+
+  .tier-heading {
+    font-family: var(--font-heading);
+    font-size: clamp(1rem, 2.5vw, 1.4rem);
+    color: var(--color-accent-green);
+    text-transform: uppercase;
+    letter-spacing: 0.2em;
+    margin-bottom: 1rem;
+  }
+
+  /* -- Slot grid -- */
+
+  .tier-slots {
+    display: grid;
+    justify-content: center;
+    gap: 1rem;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+
+  .tier-slots--host {
+    grid-template-columns: minmax(0, 640px);
+  }
+
+  .tier-slots--diamond,
+  .tier-slots--gold {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .tier-slots--community {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  @media (max-width: 48rem) {
+    .tier-slots--diamond,
+    .tier-slots--gold {
+      grid-template-columns: 1fr;
+    }
+
+    .tier-slots--community {
+      grid-template-columns: repeat(2, 1fr);
+    }
+  }
+
+  /* -- Individual slot -- */
+
+  .sponsor-slot {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 0;
+    overflow: hidden;
+    background: rgb(15 23 42 / 50%);
+    border: 1px dashed rgb(148 163 184 / 45%);
+    border-radius: 12px;
+    transition:
+      border-color var(--duration-fast) ease,
+      box-shadow var(--duration-fast) ease;
+  }
+
+  .sponsor-slot:hover {
+    border-color: rgb(148 163 184 / 70%);
+  }
+
+  .sponsor-slot--surface-light {
+    background: rgb(255 255 255 / 98%);
+    border: 1px solid rgb(226 232 240 / 75%);
+  }
+
+  /* Shape variants */
+  .sponsor-slot--card {
+    aspect-ratio: 7 / 3;
+    padding: 0.75rem 2rem;
+  }
+
+  .sponsor-slot--square {
+    aspect-ratio: 1;
+    padding: 2rem;
+  }
+
+  /* -- Logo / placeholder -- */
+
+  .sponsor-logo-link {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+  }
+
+  .sponsor-logo {
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
+  }
+
+  .sponsor-slot__plus {
+    font-size: 2.5rem;
+    font-weight: 300;
+    color: rgb(148 163 184 / 55%);
+    line-height: 1;
+    user-select: none;
+  }
+</style>

--- a/src/components/SponsorsSection.astro
+++ b/src/components/SponsorsSection.astro
@@ -1,304 +1,72 @@
 ---
 import SponsorCTA from "./SponsorCTA.astro";
+import SponsorTier from "./SponsorTier.astro";
 import { sponsorLogosByTier } from "../data/sponsorLogos";
-import { publicAssetUrl } from "../data/siteLogos";
-
-const diamondSlotTotal = 2;
-const goldSlotTotal = 2;
-const communitySlotTotal = 4;
-
-const hostLogos = sponsorLogosByTier.host;
-const diamondLogos = sponsorLogosByTier.diamond;
-const goldLogos = sponsorLogosByTier.gold;
-const communityLogos = sponsorLogosByTier.community;
-
-const base = import.meta.env.BASE_URL;
-
-const diamondPlaceholderCount = Math.max(
-  0,
-  diamondSlotTotal - diamondLogos.length,
-);
-const goldPlaceholderCount = Math.max(0, goldSlotTotal - goldLogos.length);
-const communityPlaceholderCount = Math.max(
-  0,
-  communitySlotTotal - communityLogos.length,
-);
+import Section from "./primitives/Section.astro";
+import SectionHeader from "./primitives/SectionHeader.astro";
 ---
 
-<section
-  class="sponsors-section"
+<Section
   id="sponsors"
-  aria-labelledby="sponsors-heading"
+  labelledBy="sponsors-heading"
+  width="wide"
+  padding="none"
+  style="padding: 2rem 2rem 5rem;"
 >
-  <div class="container">
-    <h2 id="sponsors-heading" class="section-title">Sponsors</h2>
-    <p class="section-subtitle">
-      Thank you to the organizations backing HackMI. Interested in joining them?
-    </p>
-
-    <div class="sponsor-tiers">
-      <section
-        class="sponsor-tier sponsor-tier--host"
-        aria-labelledby="tier-host-heading"
-      >
-        <h3 id="tier-host-heading" class="tier-heading">Host</h3>
-        <ul class="tier-slots tier-slots--host">
-          {
-            hostLogos.map((logo) => (
-              <li
-                class:list={[
-                  "sponsor-slot",
-                  "sponsor-slot--card",
-                  logo.surface === "light" && "sponsor-slot--surface-light",
-                ]}
-                aria-label={`Host sponsor — ${logo.alt}`}
-              >
-                {logo.href ? (
-                  <a
-                    class="sponsor-logo-link"
-                    href={logo.href}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <img
-                      class="sponsor-logo"
-                      src={publicAssetUrl(base, logo.src)}
-                      alt={logo.alt}
-                      loading="lazy"
-                      decoding="async"
-                    />
-                  </a>
-                ) : (
-                  <img
-                    class="sponsor-logo"
-                    src={publicAssetUrl(base, logo.src)}
-                    alt={logo.alt}
-                    loading="lazy"
-                    decoding="async"
-                  />
-                )}
-              </li>
-            ))
-          }
-        </ul>
-      </section>
-
-      <section
-        class="sponsor-tier sponsor-tier--diamond"
-        aria-labelledby="tier-diamond-heading"
-      >
-        <h3 id="tier-diamond-heading" class="tier-heading">Diamond</h3>
-        <ul class="tier-slots tier-slots--diamond">
-          {
-            diamondLogos.map((logo) => (
-              <li
-                class:list={[
-                  "sponsor-slot",
-                  "sponsor-slot--card",
-                  logo.surface === "light" && "sponsor-slot--surface-light",
-                ]}
-                aria-label={`Diamond sponsor — ${logo.alt}`}
-              >
-                {logo.href ? (
-                  <a
-                    class="sponsor-logo-link"
-                    href={logo.href}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <img
-                      class="sponsor-logo"
-                      src={publicAssetUrl(base, logo.src)}
-                      alt={logo.alt}
-                      loading="lazy"
-                      decoding="async"
-                    />
-                  </a>
-                ) : (
-                  <img
-                    class="sponsor-logo"
-                    src={publicAssetUrl(base, logo.src)}
-                    alt={logo.alt}
-                    loading="lazy"
-                    decoding="async"
-                  />
-                )}
-              </li>
-            ))
-          }
-          {
-            Array.from(
-              { length: diamondPlaceholderCount },
-              (_, i) => i + 1,
-            ).map((n) => (
-              <li
-                class="sponsor-slot sponsor-slot--card"
-                aria-label={`Diamond sponsor slot ${diamondLogos.length + n} of ${diamondSlotTotal} — logo placeholder`}
-              >
-                <span class="sponsor-slot__plus" aria-hidden="true">
-                  +
-                </span>
-              </li>
-            ))
-          }
-        </ul>
-      </section>
-
-      <section
-        class="sponsor-tier sponsor-tier--gold"
-        aria-labelledby="tier-gold-heading"
-      >
-        <h3 id="tier-gold-heading" class="tier-heading">Gold</h3>
-        <ul class="tier-slots tier-slots--gold">
-          {
-            goldLogos.map((logo) => (
-              <li
-                class:list={[
-                  "sponsor-slot",
-                  "sponsor-slot--card",
-                  logo.surface === "light" && "sponsor-slot--surface-light",
-                ]}
-                aria-label={`Gold sponsor — ${logo.alt}`}
-              >
-                {logo.href ? (
-                  <a
-                    class="sponsor-logo-link"
-                    href={logo.href}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <img
-                      class="sponsor-logo"
-                      src={publicAssetUrl(base, logo.src)}
-                      alt={logo.alt}
-                      loading="lazy"
-                      decoding="async"
-                    />
-                  </a>
-                ) : (
-                  <img
-                    class="sponsor-logo"
-                    src={publicAssetUrl(base, logo.src)}
-                    alt={logo.alt}
-                    loading="lazy"
-                    decoding="async"
-                  />
-                )}
-              </li>
-            ))
-          }
-          {
-            Array.from({ length: goldPlaceholderCount }, (_, i) => i + 1).map(
-              (n) => (
-                <li
-                  class="sponsor-slot sponsor-slot--card"
-                  aria-label={`Gold sponsor slot ${goldLogos.length + n} of ${goldSlotTotal} — logo placeholder`}
-                >
-                  <span class="sponsor-slot__plus" aria-hidden="true">
-                    +
-                  </span>
-                </li>
-              ),
-            )
-          }
-        </ul>
-      </section>
-
-      <section
-        class="sponsor-tier sponsor-tier--community"
-        aria-labelledby="tier-community-heading"
-      >
-        <h3 id="tier-community-heading" class="tier-heading">Community</h3>
-        <ul class="tier-slots tier-slots--community">
-          {
-            communityLogos.map((logo) => (
-              <li
-                class:list={[
-                  "sponsor-slot",
-                  "sponsor-slot--tile",
-                  logo.surface === "light" && "sponsor-slot--surface-light",
-                ]}
-                aria-label={`Community sponsor — ${logo.alt}`}
-              >
-                {logo.href ? (
-                  <a
-                    class="sponsor-logo-link"
-                    href={logo.href}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <img
-                      class="sponsor-logo"
-                      src={publicAssetUrl(base, logo.src)}
-                      alt={logo.alt}
-                      loading="lazy"
-                      decoding="async"
-                    />
-                  </a>
-                ) : (
-                  <img
-                    class="sponsor-logo"
-                    src={publicAssetUrl(base, logo.src)}
-                    alt={logo.alt}
-                    loading="lazy"
-                    decoding="async"
-                  />
-                )}
-              </li>
-            ))
-          }
-          {
-            Array.from(
-              { length: communityPlaceholderCount },
-              (_, i) => i + 1,
-            ).map((n) => (
-              <li
-                class="sponsor-slot sponsor-slot--tile"
-                aria-label={`Community sponsor slot ${communityLogos.length + n} of ${communitySlotTotal} — logo placeholder`}
-              >
-                <span class="sponsor-slot__plus" aria-hidden="true">
-                  +
-                </span>
-              </li>
-            ))
-          }
-        </ul>
-      </section>
-    </div>
-
-    <SponsorCTA />
+  <div class="sponsors-header-wrap">
+    <SectionHeader
+      id="sponsors-heading"
+      title="Sponsors"
+      subtitle="Thank you to the organizations backing HackMI. Interested in joining them?"
+    />
   </div>
-</section>
+
+  <div class="sponsor-tiers">
+    <SponsorTier
+      heading="Host"
+      headingId="tier-host-heading"
+      logos={sponsorLogosByTier.host}
+      totalSlots={sponsorLogosByTier.host.length}
+      layout="host"
+      shape="card"
+      slotLabel="Host sponsor"
+    />
+    <SponsorTier
+      heading="Diamond"
+      headingId="tier-diamond-heading"
+      logos={sponsorLogosByTier.diamond}
+      totalSlots={2}
+      layout="diamond"
+      shape="card"
+      slotLabel="Diamond sponsor"
+    />
+    <SponsorTier
+      heading="Gold"
+      headingId="tier-gold-heading"
+      logos={sponsorLogosByTier.gold}
+      totalSlots={2}
+      layout="gold"
+      shape="card"
+      slotLabel="Gold sponsor"
+    />
+    <SponsorTier
+      heading="Community"
+      headingId="tier-community-heading"
+      logos={sponsorLogosByTier.community}
+      totalSlots={4}
+      layout="community"
+      shape="square"
+      slotLabel="Community sponsor"
+    />
+  </div>
+
+  <SponsorCTA />
+</Section>
 
 <style>
-  .sponsors-section {
-    padding: 2rem 2rem 5rem;
-    position: relative;
-  }
-
-  .container {
-    max-width: 1400px;
-    margin: 0 auto;
-  }
-
-  .section-title {
-    font-family: var(--font-heading);
-    font-size: clamp(2rem, 5vw, 3rem);
-    font-weight: 700;
-    text-align: center;
-    margin-bottom: 0.75rem;
-    color: var(--color-accent-green);
-  }
-
-  .section-subtitle {
-    text-align: center;
-    color: var(--color-text-dim);
+  .sponsors-header-wrap :global(.section-subtitle) {
     text-transform: uppercase;
-    font-size: 1.1rem;
-    margin-bottom: 2rem;
     max-width: 640px;
-    margin-left: auto;
-    margin-right: auto;
   }
 
   .sponsor-tiers {
@@ -307,162 +75,5 @@ const communityPlaceholderCount = Math.max(
     gap: 2.75rem;
     margin-top: 2.5rem;
     margin-bottom: 2.5rem;
-  }
-
-  .sponsor-tier {
-    width: 100%;
-  }
-
-  .tier-heading {
-    font-family: var(--font-heading);
-    font-size: 1.4rem;
-    font-weight: 700;
-    letter-spacing: 0.2em;
-    text-transform: uppercase;
-    color: var(--color-accent-green);
-    text-align: center;
-    margin-bottom: 1rem;
-  }
-
-  .tier-slots {
-    display: grid;
-    gap: 1rem;
-    width: 100%;
-    list-style: none;
-    margin: 0;
-    padding: 0;
-  }
-
-  /* Host: single row, one business-card slot (centered) */
-  .tier-slots--host {
-    grid-template-columns: 1fr;
-    justify-items: center;
-    max-width: min(640px, 100%);
-    margin: 0 auto;
-  }
-
-  /* Diamond: two across */
-  .tier-slots--diamond {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  /* Gold: two across */
-  .tier-slots--gold {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  /* Community: one row, four across */
-  .tier-slots--community {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-  }
-
-  .sponsor-slot {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 100%;
-    box-sizing: border-box;
-    border-radius: 0.75rem;
-    border: 1px dashed rgba(148, 163, 184, 0.45);
-    background-color: rgba(15, 23, 42, 0.5);
-    transition:
-      border-color 0.2s ease,
-      background-color 0.2s ease;
-  }
-
-  .sponsor-logo-link {
-    display: flex;
-    width: 100%;
-    height: 100%;
-    align-items: center;
-    justify-content: center;
-    padding: 0.75rem;
-    border-radius: 0.75rem;
-    text-decoration: none;
-  }
-
-  .tier-slots--host .sponsor-slot {
-    padding-inline: 2rem;
-    padding-block: 0.75rem;
-  }
-
-  .tier-slots--community .sponsor-slot {
-    padding: 2rem;
-  }
-
-  .sponsor-logo {
-    display: block;
-    max-width: 100%;
-    max-height: 100%;
-    object-fit: contain;
-    filter: saturate(1.02) contrast(1.02);
-  }
-
-  .sponsor-slot--card {
-    aspect-ratio: 7 / 3;
-  }
-
-  .sponsor-slot--tile {
-    aspect-ratio: 1 / 1;
-  }
-
-  .sponsor-slot:hover {
-    border-color: rgba(59, 130, 246, 0.55);
-    background-color: rgba(30, 41, 59, 0.55);
-  }
-
-  .sponsor-slot--surface-light {
-    border-style: solid;
-    border-color: rgba(226, 232, 240, 0.75);
-    background: rgba(255, 255, 255, 0.98);
-  }
-
-  .sponsor-slot--surface-light:hover {
-    border-color: rgba(148, 163, 184, 0.95);
-    background: rgba(255, 255, 255, 1);
-  }
-
-  .sponsor-slot__plus {
-    font-family: var(--font-heading);
-    font-size: clamp(2rem, 5vw, 2.75rem);
-    font-weight: 500;
-    line-height: 1;
-    color: rgba(148, 163, 184, 0.55);
-    user-select: none;
-    pointer-events: none;
-  }
-
-  @media (max-width: 900px) {
-    .tier-slots--gold {
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-    }
-
-    .tier-slots--community {
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-    }
-  }
-
-  @media (max-width: 640px) {
-    .tier-slots--diamond {
-      grid-template-columns: 1fr;
-      aspect-ratio: 2 / 1;
-    }
-
-    .tier-slots--gold {
-      grid-template-columns: 1fr;
-      aspect-ratio: 2 / 1;
-    }
-
-    .sponsors-section {
-      padding: 1.5rem 1.25rem 4rem;
-    }
-
-    .tier-slots--community {
-      grid-template-columns: 1fr;
-    }
-
-    .sponsor-slot--tile {
-      aspect-ratio: 2 / 1;
-    }
   }
 </style>

--- a/src/components/ThreeBackground.astro
+++ b/src/components/ThreeBackground.astro
@@ -43,7 +43,6 @@
 <script>
   import * as THREE from "three";
 
-  // Three.js animation setup and lifecycle management
   let scene: THREE.Scene | null = null;
   let camera: THREE.PerspectiveCamera | null = null;
   let renderer: THREE.WebGLRenderer | null = null;
@@ -60,15 +59,15 @@
   let mouseY = 0;
   let time = 0;
   let isPaused = false;
+  let isOffscreen = false;
   let pauseButtonHandler: (() => void) | null = null;
+  let observer: IntersectionObserver | null = null;
 
-  // Mouse move handler
   const handleMouseMove = (event: MouseEvent) => {
     mouseX = (event.clientX / window.innerWidth) * 2 - 1;
     mouseY = -(event.clientY / window.innerHeight) * 2 + 1;
   };
 
-  // Resize handler
   const handleResize = () => {
     if (!camera || !renderer) return;
     camera.aspect = window.innerWidth / window.innerHeight;
@@ -76,15 +75,21 @@
     renderer.setSize(window.innerWidth, window.innerHeight);
   };
 
-  // Initialize the Three.js scene
+  function shouldAnimate() {
+    return !isPaused && !isOffscreen;
+  }
+
   function initThreeAnimation() {
     const canvas = document.getElementById("three-canvas") as HTMLCanvasElement;
     if (!canvas) return;
 
-    // Clean up any previous instance (important for Astro view transitions)
     cleanupThreeAnimation();
 
-    // Scene, camera, and renderer
+    // Auto-pause for reduced motion
+    const prefersReduced = window.matchMedia(
+      "(prefers-reduced-motion: reduce)",
+    ).matches;
+
     scene = new THREE.Scene();
     camera = new THREE.PerspectiveCamera(
       75,
@@ -99,35 +104,30 @@
     });
 
     renderer.setSize(window.innerWidth, window.innerHeight);
-    renderer.setPixelRatio(window.devicePixelRatio);
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
     camera.position.z = 5;
 
-    // Particle system
+    // Particles
     const particlesGeometry = new THREE.BufferGeometry();
     const particlesCount = 5000;
     const posArray = new Float32Array(particlesCount * 3);
     const colorArray = new Float32Array(particlesCount * 3);
 
     for (let i = 0; i < particlesCount * 3; i += 3) {
-      // Random positions
       posArray[i] = (Math.random() - 0.5) * 100;
       posArray[i + 1] = (Math.random() - 0.5) * 100;
       posArray[i + 2] = (Math.random() - 0.5) * 100;
 
-      // Random colors (purple, pink, blue family)
       const colorType = Math.random();
       if (colorType < 0.33) {
-        // Purple
         colorArray[i] = 0.66;
         colorArray[i + 1] = 0.33;
         colorArray[i + 2] = 0.97;
       } else if (colorType < 0.66) {
-        // Pink
         colorArray[i] = 0.93;
         colorArray[i + 1] = 0.28;
         colorArray[i + 2] = 0.6;
       } else {
-        // Blue
         colorArray[i] = 0.23;
         colorArray[i + 1] = 0.51;
         colorArray[i + 2] = 0.96;
@@ -143,7 +143,6 @@
       new THREE.BufferAttribute(colorArray, 3),
     );
 
-    // Particle material
     const particlesMaterial = new THREE.PointsMaterial({
       size: 0.15,
       vertexColors: true,
@@ -155,7 +154,7 @@
     particlesMesh = new THREE.Points(particlesGeometry, particlesMaterial);
     scene.add(particlesMesh);
 
-    // Rotating torus (donut)
+    // Tori
     const torusGeometry = new THREE.TorusGeometry(10, 3, 16, 100);
     const torusMaterial = new THREE.MeshBasicMaterial({
       color: 0xa855f7,
@@ -166,7 +165,6 @@
     torus = new THREE.Mesh(torusGeometry, torusMaterial);
     scene.add(torus);
 
-    // Second torus
     const torus2Geometry = new THREE.TorusGeometry(15, 2, 16, 100);
     const torus2Material = new THREE.MeshBasicMaterial({
       color: 0xec4899,
@@ -178,14 +176,28 @@
     torus2.rotation.x = Math.PI / 4;
     scene.add(torus2);
 
-    // Event listeners
     document.addEventListener("mousemove", handleMouseMove);
     window.addEventListener("resize", handleResize);
 
-    // Start animation loop
+    // IntersectionObserver: pause when offscreen
+    observer = new IntersectionObserver(
+      ([entry]) => {
+        isOffscreen = !entry.isIntersecting;
+        if (shouldAnimate() && animationId === null) animate();
+        if (!shouldAnimate() && animationId !== null) {
+          cancelAnimationFrame(animationId);
+          animationId = null;
+        }
+      },
+      { threshold: 0 },
+    );
+    observer.observe(canvas);
+
     time = 0;
-    isPaused = false;
-    animate();
+    isPaused = prefersReduced;
+    isOffscreen = false;
+
+    if (shouldAnimate()) animate();
     setupPauseButton();
   }
 
@@ -195,13 +207,14 @@
     const pauseIcon = btn.querySelector(".three-pause-icon--pause");
     const playIcon = btn.querySelector(".three-pause-icon--play");
     btn.setAttribute("aria-pressed", isPaused ? "true" : "false");
-    if (isPaused) {
-      btn.setAttribute("aria-label", "Resume background animation");
-      btn.setAttribute("title", "Resume background animation");
-    } else {
-      btn.setAttribute("aria-label", "Pause background animation");
-      btn.setAttribute("title", "Pause background animation");
-    }
+    btn.setAttribute(
+      "aria-label",
+      isPaused ? "Resume background animation" : "Pause background animation",
+    );
+    btn.setAttribute(
+      "title",
+      isPaused ? "Resume background animation" : "Pause background animation",
+    );
     if (pauseIcon && playIcon) {
       pauseIcon.toggleAttribute("hidden", isPaused);
       playIcon.toggleAttribute("hidden", !isPaused);
@@ -210,13 +223,13 @@
 
   function setPaused(paused: boolean) {
     isPaused = paused;
-    if (isPaused) {
+    if (!shouldAnimate()) {
       if (animationId !== null) {
         cancelAnimationFrame(animationId);
         animationId = null;
       }
     } else {
-      animate();
+      if (animationId === null) animate();
     }
     syncPauseButton();
   }
@@ -224,9 +237,8 @@
   function setupPauseButton() {
     const btn = document.getElementById("three-pause-toggle");
     if (!btn) return;
-    if (pauseButtonHandler) {
+    if (pauseButtonHandler)
       btn.removeEventListener("click", pauseButtonHandler);
-    }
     pauseButtonHandler = () => setPaused(!isPaused);
     btn.addEventListener("click", pauseButtonHandler);
     syncPauseButton();
@@ -234,19 +246,16 @@
 
   function cleanupPauseButton() {
     const btn = document.getElementById("three-pause-toggle");
-    if (btn && pauseButtonHandler) {
+    if (btn && pauseButtonHandler)
       btn.removeEventListener("click", pauseButtonHandler);
-    }
     pauseButtonHandler = null;
     isPaused = false;
   }
 
-  // Animation loop
   function animate() {
     if (!scene || !camera || !renderer || !particlesMesh || !torus || !torus2)
       return;
-
-    if (isPaused) {
+    if (!shouldAnimate()) {
       animationId = null;
       return;
     }
@@ -254,11 +263,9 @@
     animationId = requestAnimationFrame(animate);
     time += 0.001;
 
-    // パーティクルの回転とうねり
     particlesMesh.rotation.y = time * 0.3;
     particlesMesh.rotation.x = Math.sin(time) * 0.1;
 
-    // トーラスの回転
     torus.rotation.x += 0.01;
     torus.rotation.y += 0.005;
     torus.rotation.z += 0.003;
@@ -267,7 +274,6 @@
     torus2.rotation.y += 0.01;
     torus2.rotation.z += 0.002;
 
-    // マウス追従
     camera.position.x = mouseX * 2;
     camera.position.y = mouseY * 2;
     camera.lookAt(scene.position);
@@ -275,57 +281,49 @@
     renderer.render(scene, camera);
   }
 
-  // Cleanup
   function cleanupThreeAnimation() {
     cleanupPauseButton();
 
-    // Stop animation loop
+    if (observer) {
+      observer.disconnect();
+      observer = null;
+    }
+
     if (animationId !== null) {
       cancelAnimationFrame(animationId);
       animationId = null;
     }
 
-    // Remove event listeners
     document.removeEventListener("mousemove", handleMouseMove);
     window.removeEventListener("resize", handleResize);
 
-    // Dispose Three.js objects
     if (particlesMesh) {
       particlesMesh.geometry.dispose();
       particlesMesh.material.dispose();
       particlesMesh = null;
     }
-
     if (torus) {
       torus.geometry.dispose();
       torus.material.dispose();
       torus = null;
     }
-
     if (torus2) {
       torus2.geometry.dispose();
       torus2.material.dispose();
       torus2 = null;
     }
-
     if (renderer) {
       renderer.dispose();
       renderer = null;
     }
-
     scene = null;
     camera = null;
   }
 
-  // Initialize on Astro page load (view transitions safe)
-  document.addEventListener("astro:page-load", () => {
-    initThreeAnimation();
-  });
-
-  // Cleanup before navigating away
-  document.addEventListener("astro:before-preparation", () => {
-    cleanupThreeAnimation();
-  });
+  document.addEventListener("astro:page-load", () => initThreeAnimation());
+  document.addEventListener("astro:before-preparation", () =>
+    cleanupThreeAnimation(),
+  );
 </script>
 
 <style>
@@ -352,23 +350,23 @@
     padding: 0;
     border: 1px solid var(--color-border);
     border-radius: 0.65rem;
-    background: rgba(15, 23, 42, 0.88);
+    background: rgb(15 23 42 / 88%);
     backdrop-filter: blur(10px);
     -webkit-backdrop-filter: blur(10px);
     color: var(--color-text);
     cursor: pointer;
-    box-shadow: 0 4px 24px rgba(0, 0, 0, 0.35);
+    box-shadow: 0 4px 24px rgb(0 0 0 / 35%);
     transition:
-      border-color 0.2s ease,
-      color 0.2s ease,
-      background 0.2s ease;
+      border-color var(--duration-fast) ease,
+      color var(--duration-fast) ease,
+      background var(--duration-fast) ease;
     touch-action: manipulation;
   }
 
   .three-pause-btn:hover {
     border-color: var(--color-primary);
     color: var(--color-primary);
-    background: rgba(30, 41, 59, 0.95);
+    background: rgb(30 41 59 / 95%);
   }
 
   .three-pause-btn:focus-visible {
@@ -386,7 +384,7 @@
     display: none;
   }
 
-  @media (max-width: 768px) {
+  @media (max-width: 48rem) {
     .three-pause-btn {
       bottom: 1rem;
       right: 1rem;

--- a/src/components/primitives/Button.astro
+++ b/src/components/primitives/Button.astro
@@ -1,0 +1,57 @@
+---
+/**
+ * Button - polymorphic anchor/button primitive.
+ *
+ * Renders `<a>` when `href` is provided, otherwise `<button>`. External links
+ * (absolute http(s) URLs) auto-open in a new tab with safe `rel` by default.
+ * Variants map to shared `.btn-*` utility classes in `global.css`.
+ */
+import type { HTMLAttributes } from "astro/types";
+
+type Variant = "primary" | "secondary" | "ghost" | "mega";
+type ExtraClass = "sponsor-glow" | "block-on-mobile";
+
+interface Props extends Omit<HTMLAttributes<"a">, "type"> {
+  variant?: Variant;
+  /** Additional decorative classes (e.g. "sponsor-glow"). */
+  accent?: ExtraClass | ExtraClass[];
+  /** Force external behaviour (target=_blank + safe rel). Auto-detected for http(s) hrefs. */
+  external?: boolean;
+  /** When rendering a `<button>`, its type attribute. */
+  type?: "button" | "submit" | "reset";
+}
+
+const {
+  variant = "primary",
+  accent,
+  external,
+  href,
+  type = "button",
+  class: className,
+  ...rest
+} = Astro.props;
+
+const accents = Array.isArray(accent) ? accent : accent ? [accent] : [];
+const accentClasses = accents.map((a) => `btn-${a}`);
+
+const isExternalHref = typeof href === "string" && /^https?:\/\//i.test(href);
+const treatAsExternal = external ?? isExternalHref;
+
+const linkAttrs = treatAsExternal
+  ? { target: "_blank", rel: "noopener noreferrer" }
+  : {};
+
+const classes = ["btn", `btn-${variant}`, ...accentClasses, className];
+---
+
+{
+  href ? (
+    <a href={href} class:list={classes} {...linkAttrs} {...rest}>
+      <slot />
+    </a>
+  ) : (
+    <button type={type} class:list={classes} {...rest}>
+      <slot />
+    </button>
+  )
+}

--- a/src/components/primitives/GlassCard.astro
+++ b/src/components/primitives/GlassCard.astro
@@ -1,0 +1,40 @@
+---
+/**
+ * GlassCard - frosted-panel surface primitive.
+ *
+ * Emits an `<article>` by default; pass `as` to override. Variants map to
+ * shared `.glass-card*` utilities in `global.css`.
+ */
+import type { HTMLTag } from "astro/types";
+
+interface Props {
+  as?: HTMLTag;
+  elevation?: "flat" | "raised";
+  interactive?: boolean;
+  /** Hover accent color family. */
+  hover?: "blue" | "violet";
+  id?: string;
+  class?: string;
+}
+
+const {
+  as: Tag = "article",
+  elevation = "flat",
+  interactive = false,
+  hover = "blue",
+  id,
+  class: className,
+}: Props = Astro.props;
+
+const classes = [
+  "glass-card",
+  elevation === "raised" && "glass-card--raised",
+  interactive && "glass-card--interactive",
+  interactive && hover === "violet" && "glass-card--interactive-violet",
+  className,
+];
+---
+
+<Tag id={id} class:list={classes}>
+  <slot />
+</Tag>

--- a/src/components/primitives/Icon.astro
+++ b/src/components/primitives/Icon.astro
@@ -5,8 +5,11 @@
  * Reference icons by filename (without `.svg`).
  * Pass `label` for meaningful icons; omit for decorative.
  */
-import fs from "node:fs";
-import path from "node:path";
+const icons = import.meta.glob<string>("/src/icons/*.svg", {
+  query: "?raw",
+  import: "default",
+  eager: true,
+});
 
 interface Props {
   name: string;
@@ -17,10 +20,16 @@ interface Props {
 
 const { name, size = 20, label, class: className } = Astro.props;
 
-const svgPath = path.resolve(`src/icons/${name}.svg`);
-let raw = fs.readFileSync(svgPath, "utf-8");
+const key = `/src/icons/${name}.svg`;
+const raw = icons[key];
+if (!raw)
+  throw new Error(
+    `Icon "${name}" not found. Available: ${Object.keys(icons)
+      .map((k) => k.split("/").pop()?.replace(".svg", ""))
+      .join(", ")}`,
+  );
 
-// inject size + a11y attrs into the opening <svg> tag
+// inject size + a11y attrs into opening <svg> tag
 const attrs = [
   `width="${size}"`,
   `height="${size}"`,
@@ -28,10 +37,10 @@ const attrs = [
   label ? `aria-label="${label}" role="img"` : `aria-hidden="true"`,
 ].join(" ");
 
-raw = raw.replace("<svg", `<svg ${attrs}`);
+const svg = raw.replace("<svg", `<svg ${attrs}`);
 ---
 
-<Fragment set:html={raw} />
+<Fragment set:html={svg} />
 
 <style>
   .icon {

--- a/src/components/primitives/Icon.astro
+++ b/src/components/primitives/Icon.astro
@@ -1,0 +1,42 @@
+---
+/**
+ * Icon - inlines SVGs from `src/icons/` with normalized size + a11y.
+ *
+ * Reference icons by filename (without `.svg`).
+ * Pass `label` for meaningful icons; omit for decorative.
+ */
+import fs from "node:fs";
+import path from "node:path";
+
+interface Props {
+  name: string;
+  size?: number | string;
+  label?: string;
+  class?: string;
+}
+
+const { name, size = 20, label, class: className } = Astro.props;
+
+const svgPath = path.resolve(`src/icons/${name}.svg`);
+let raw = fs.readFileSync(svgPath, "utf-8");
+
+// inject size + a11y attrs into the opening <svg> tag
+const attrs = [
+  `width="${size}"`,
+  `height="${size}"`,
+  `class="${["icon", className].filter(Boolean).join(" ")}"`,
+  label ? `aria-label="${label}" role="img"` : `aria-hidden="true"`,
+].join(" ");
+
+raw = raw.replace("<svg", `<svg ${attrs}`);
+---
+
+<Fragment set:html={raw} />
+
+<style>
+  .icon {
+    display: inline-block;
+    flex-shrink: 0;
+    vertical-align: middle;
+  }
+</style>

--- a/src/components/primitives/MaybeLink.astro
+++ b/src/components/primitives/MaybeLink.astro
@@ -1,0 +1,33 @@
+---
+/**
+ * MaybeLink - renders an anchor when `href` is set, otherwise a passthrough span.
+ *
+ * Used for sponsor-logo wrappers where a website URL may or may not be present.
+ * External http(s) hrefs get `target=_blank` + safe `rel` automatically.
+ */
+import type { HTMLAttributes } from "astro/types";
+
+interface Props extends Omit<HTMLAttributes<"a">, "href"> {
+  /** Optional URL; when omitted a `<span>` is rendered instead. */
+  href?: string | null | undefined;
+}
+
+const { href, class: className, ...rest } = Astro.props;
+
+const isExternal = typeof href === "string" && /^https?:\/\//i.test(href);
+const linkAttrs = isExternal
+  ? { target: "_blank", rel: "noopener noreferrer" }
+  : {};
+---
+
+{
+  href ? (
+    <a href={href} class:list={[className]} {...linkAttrs} {...rest}>
+      <slot />
+    </a>
+  ) : (
+    <span class:list={[className]}>
+      <slot />
+    </span>
+  )
+}

--- a/src/components/primitives/MaybeLink.astro
+++ b/src/components/primitives/MaybeLink.astro
@@ -26,7 +26,7 @@ const linkAttrs = isExternal
       <slot />
     </a>
   ) : (
-    <span class:list={[className]}>
+    <span class:list={[className]} {...rest}>
       <slot />
     </span>
   )

--- a/src/components/primitives/Section.astro
+++ b/src/components/primitives/Section.astro
@@ -1,0 +1,87 @@
+---
+/**
+ * Section - page section shell with consistent vertical rhythm + container.
+ *
+ * Wires up `aria-labelledby` via the provided `labelledBy` id. Renders an
+ * inner `.section-container` unless `bare` is set.
+ */
+interface Props {
+  id?: string;
+  labelledBy?: string;
+  /** Container width preset. */
+  width?: "default" | "narrow" | "wide";
+  /** Vertical padding preset. */
+  padding?: "default" | "compact" | "loose" | "none";
+  /** When true, the inner container is omitted (slot is the direct child). */
+  bare?: boolean;
+  class?: string;
+  /** Inline style override (e.g. custom padding). */
+  style?: string;
+}
+
+const {
+  id,
+  labelledBy,
+  width = "default",
+  padding = "default",
+  bare = false,
+  class: className,
+  style,
+} = Astro.props;
+
+const widthClass =
+  width === "narrow"
+    ? "section-container--narrow"
+    : width === "wide"
+      ? "section-container--wide"
+      : undefined;
+
+const sectionClasses = ["page-section", `page-section--${padding}`, className];
+---
+
+<section
+  id={id}
+  aria-labelledby={labelledBy}
+  class:list={sectionClasses}
+  style={style}
+>
+  {
+    bare ? (
+      <slot />
+    ) : (
+      <div class:list={["section-container", widthClass]}>
+        <slot />
+      </div>
+    )
+  }
+</section>
+
+<style>
+  .page-section {
+    position: relative;
+  }
+
+  .page-section--default {
+    padding: var(--space-3xl) var(--space-lg);
+  }
+
+  .page-section--compact {
+    padding: var(--space-2xl) var(--space-lg);
+  }
+
+  .page-section--loose {
+    padding: var(--space-3xl) var(--space-lg) var(--space-3xl);
+  }
+
+  .page-section--none {
+    padding: 0;
+  }
+
+  @media (max-width: 48rem) {
+    .page-section--default,
+    .page-section--compact,
+    .page-section--loose {
+      padding-inline: 1.25rem;
+    }
+  }
+</style>

--- a/src/components/primitives/SectionHeader.astro
+++ b/src/components/primitives/SectionHeader.astro
@@ -1,0 +1,50 @@
+---
+/**
+ * SectionHeader - eyebrow + title + optional subtitle.
+ *
+ * The `id` is attached to the heading so a parent `<section aria-labelledby>`
+ * can reference it. Pairs with the <Section> primitive.
+ */
+interface Props {
+  title: string;
+  subtitle?: string;
+  eyebrow?: string;
+  /** Heading id (also exposed for aria-labelledby on ancestor). */
+  id?: string;
+  /** Heading level (defaults to 2). */
+  level?: 1 | 2 | 3;
+  align?: "center" | "start";
+  class?: string;
+}
+
+const {
+  title,
+  subtitle,
+  eyebrow,
+  id,
+  level = 2,
+  align = "center",
+  class: className,
+} = Astro.props;
+
+const Heading = `h${level}` as const;
+const alignStyle = align === "start" ? "text-align: start;" : undefined;
+---
+
+<header class:list={["section-header", className]} style={alignStyle}>
+  {eyebrow && <p class="section-eyebrow">{eyebrow}</p>}
+  <Heading id={id} class="section-title">{title}</Heading>
+  {
+    subtitle && (
+      <p class="section-subtitle">
+        <slot name="subtitle">{subtitle}</slot>
+      </p>
+    )
+  }
+</header>
+
+<style>
+  .section-header {
+    margin-bottom: var(--space-lg);
+  }
+</style>

--- a/src/data/event.ts
+++ b/src/data/event.ts
@@ -1,0 +1,28 @@
+/**
+ * Event metadata for Hack Michigan 2026.
+ *
+ * Single source of truth for event metadata and external URLs.
+ */
+
+export const EVENT = {
+  name: "Hack Michigan",
+  tagline: "Building the future of Michigan's tech corridor.",
+  mission:
+    "Hack Michigan is a technical-first hackathon focused on engineering excellence and the future of the Detroit tech corridor.",
+  date: "May 15-17 2026",
+  dateIso: "2026-05-15",
+  time: "2:00 PM - 2:00 PM (EDT)",
+  location: "TechTown Detroit, 440 Burroughs Street, Detroit, 48202",
+  locationUrl:
+    "https://www.google.com/maps/dir//TechTown%20Detroit%20440%20Burroughs%20Street%20Detroit%2048202",
+  locationMapEmbedUrl:
+    "https://maps.google.com/maps?q=440+Burroughs+St%2C+Detroit%2C+MI+48202&output=embed&z=16",
+  teamSizeMax: 5,
+} as const;
+
+export const EVENT_URLS = {
+  hackerRegistration: "https://ibm.biz/hack-michigan",
+  sponsorInquiry: "mailto:whatupdoe@compass-detroit.com",
+} as const;
+
+export type EventUrlKey = keyof typeof EVENT_URLS;

--- a/src/data/logistics.ts
+++ b/src/data/logistics.ts
@@ -23,23 +23,23 @@ export const LOGISTICS_CARDS: readonly LogisticsCard[] = [
     rows: [
       {
         label: "Team Size:",
-        text: ` Participate individually or in teams of up to ${EVENT.teamSizeMax} people.`,
+        text: `Participate individually or in teams of up to ${EVENT.teamSizeMax} people.`,
       },
       {
         label: "Eligibility:",
-        text: " Must be 18 years or older (or age of emancipation in your jurisdiction).",
+        text: "Must be 18 years or older (or age of emancipation in your jurisdiction).",
       },
       {
         label: "Technology Requirement:",
-        text: " All submissions must use IBM watsonx technology (watsonx.ai, watsonx.data, or IBM Granite models) or other AI and Open Source technologies.",
+        text: "All submissions must use IBM watsonx technology (watsonx.ai, watsonx.data, or IBM Granite models) or other AI and Open Source technologies.",
       },
       {
         label: "Originality:",
-        text: " Projects must be original work created during the hackathon period (May 15-17, 2026).",
+        text: "Projects must be original work created during the hackathon period (May 15-17, 2026).",
       },
       {
         label: "Deliverables:",
-        text: " Each submission must include a video demonstration, written problem/solution statements, a statement on technology utilized, and optionally a working code repository.",
+        text: "Each submission must include a video demonstration, written problem/solution statements, a statement on technology utilized, and optionally a working code repository.",
       },
       {
         text: "Our goal is a fair, inclusive, and safe event for everyone. Full code of conduct and detailed rules available in the official rules document.",
@@ -78,31 +78,31 @@ export const LOGISTICS_CARDS: readonly LogisticsCard[] = [
     rows: [
       {
         label: "Completeness and Feasibility (5 points)",
-        text: " -- Is the solution complete and realistic?",
+        text: "Is the solution complete and realistic?",
       },
       {
         label: "Effectiveness and Efficiency (5 points)",
-        text: " -- Does it solve the problem well?",
+        text: "Does it solve the problem well?",
       },
       {
         label: "Design and Usability (5 points)",
-        text: " -- Is it well-designed and user-friendly?",
+        text: "Is it well-designed and user-friendly?",
       },
       {
         label: "Creativity and Innovation (5 points)",
-        text: " -- Is it innovative and creative?",
+        text: "Is it innovative and creative?",
       },
       {
         label: "Michigan Impact (5 points)",
-        text: " -- Does it keep value, jobs, and opportunity in Michigan?",
+        text: "Does it keep value, jobs, and opportunity in Michigan?",
       },
       {
         label: "Your solution should also demonstrate:",
-        text: " practical application solving a real Michigan challenge, clear business value, implementability as a working proof-of-concept, and strong storytelling that positions Michigan as a technology innovator.",
+        text: "practical application solving a real Michigan challenge, clear business value, implementability as a working proof-of-concept, and strong storytelling that positions Michigan as a technology innovator.",
       },
       {
         label: "Final scores",
-        text: " will be the average of judges' scores based on your submitted deliverables.",
+        text: "will be the average of judges' scores based on your submitted deliverables.",
       },
     ],
   },

--- a/src/data/logistics.ts
+++ b/src/data/logistics.ts
@@ -1,0 +1,109 @@
+/**
+ * Logistics cards rendered in `LogisticsSection` (rules, prizes, judges,
+ * judging criteria).
+ */
+import { EVENT } from "./event";
+
+export interface LogisticsRow {
+  readonly label?: string;
+  readonly text: string;
+}
+
+export interface LogisticsCard {
+  readonly id: string;
+  readonly title: string;
+  readonly preamble?: string;
+  readonly rows: readonly LogisticsRow[];
+}
+
+export const LOGISTICS_CARDS: readonly LogisticsCard[] = [
+  {
+    id: "rules",
+    title: "Rules",
+    rows: [
+      {
+        label: "Team Size:",
+        text: ` Participate individually or in teams of up to ${EVENT.teamSizeMax} people.`,
+      },
+      {
+        label: "Eligibility:",
+        text: " Must be 18 years or older (or age of emancipation in your jurisdiction).",
+      },
+      {
+        label: "Technology Requirement:",
+        text: " All submissions must use IBM watsonx technology (watsonx.ai, watsonx.data, or IBM Granite models) or other AI and Open Source technologies.",
+      },
+      {
+        label: "Originality:",
+        text: " Projects must be original work created during the hackathon period (May 15-17, 2026).",
+      },
+      {
+        label: "Deliverables:",
+        text: " Each submission must include a video demonstration, written problem/solution statements, a statement on technology utilized, and optionally a working code repository.",
+      },
+      {
+        text: "Our goal is a fair, inclusive, and safe event for everyone. Full code of conduct and detailed rules available in the official rules document.",
+      },
+    ],
+  },
+  {
+    id: "prizes",
+    title: "Prizes",
+    rows: [
+      {
+        text: "Top teams will receive cash prizes, IBM and partner swag, mentorship opportunities with Michigan tech leaders, and exclusive access to IBM watsonx resources to continue developing their solutions.",
+      },
+      {
+        text: "Winners will also be featured in Hack Michigan media and invited to present at future Michigan innovation events.",
+      },
+      {
+        text: "Full prize details and tiers will be announced at the opening ceremony on May 15, 2026.",
+      },
+    ],
+  },
+  {
+    id: "judges",
+    title: "Judges",
+    rows: [
+      {
+        text: "Judges from industry and academia will join us in Detroit. Names and backgrounds will be listed once the panel is confirmed.",
+      },
+    ],
+  },
+  {
+    id: "judging-criteria",
+    title: "Judging criteria",
+    preamble:
+      "Each submission will be scored on the following criteria (maximum 25 points total):",
+    rows: [
+      {
+        label: "Completeness and Feasibility (5 points)",
+        text: " -- Is the solution complete and realistic?",
+      },
+      {
+        label: "Effectiveness and Efficiency (5 points)",
+        text: " -- Does it solve the problem well?",
+      },
+      {
+        label: "Design and Usability (5 points)",
+        text: " -- Is it well-designed and user-friendly?",
+      },
+      {
+        label: "Creativity and Innovation (5 points)",
+        text: " -- Is it innovative and creative?",
+      },
+      {
+        label: "Michigan Impact (5 points)",
+        text: " -- Does it keep value, jobs, and opportunity in Michigan?",
+      },
+      {
+        label: "Your solution should also demonstrate:",
+        text: " practical application solving a real Michigan challenge, clear business value, implementability as a working proof-of-concept, and strong storytelling that positions Michigan as a technology innovator.",
+      },
+      {
+        label: "Final scores",
+        text: " will be the average of judges' scores based on your submitted deliverables.",
+      },
+    ],
+  },
+] as const;

--- a/src/data/nav.ts
+++ b/src/data/nav.ts
@@ -1,0 +1,35 @@
+/**
+ * Site navigation links and primary CTA labels.
+ *
+ * Used by `Navigation.astro` and `Footer.astro` so the link set stays
+ * consistent across header and footer.
+ */
+import { EVENT_URLS } from "./event";
+
+export interface SectionAnchor {
+  readonly href: string;
+  readonly nav: string;
+  readonly footer: string;
+}
+
+export const SECTION_ANCHORS: readonly SectionAnchor[] = [
+  { href: "#about", nav: "About", footer: "About" },
+  { href: "#sponsors", nav: "Sponsors", footer: "Sponsors" },
+  { href: "#event-details", nav: "Event", footer: "Details" },
+  { href: "#logistics", nav: "Logistics", footer: "Logistics" },
+] as const;
+
+export const PRIMARY_CTA = {
+  hacker: { href: EVENT_URLS.hackerRegistration, label: "Register" },
+  sponsor: { href: EVENT_URLS.sponsorInquiry, label: "Sponsor" },
+  sponsorLong: { href: EVENT_URLS.sponsorInquiry, label: "Become a sponsor" },
+} as const;
+
+/**
+ * Prefix an anchor-style href (`#foo`) with the deployed base URL. Absolute
+ * external URLs and `mailto:` links pass through unchanged.
+ */
+export function withBase(base: string, href: string): string {
+  if (href.startsWith("#")) return `${base}${href}`;
+  return href;
+}

--- a/src/data/socials.ts
+++ b/src/data/socials.ts
@@ -1,0 +1,17 @@
+/* Compass Detroit Links */
+
+export interface SocialLink {
+  readonly href: string;
+  readonly label: string;
+}
+
+export const SOCIAL_LINKS: readonly SocialLink[] = [
+  {
+    href: "https://www.linkedin.com/company/compass-detroit/",
+    label: "LinkedIn",
+  },
+  {
+    href: "https://github.com/Compass-Detroit/",
+    label: "GitHub",
+  },
+] as const;

--- a/src/icons/arrow-right.svg
+++ b/src/icons/arrow-right.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>

--- a/src/icons/calendar.svg
+++ b/src/icons/calendar.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>

--- a/src/icons/map-pin.svg
+++ b/src/icons/map-pin.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"/><circle cx="12" cy="10" r="3"/></svg>

--- a/src/icons/menu.svg
+++ b/src/icons/menu.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="18" x2="21" y2="18"/></svg>

--- a/src/icons/pause.svg
+++ b/src/icons/pause.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="6" y="4" width="4" height="16" rx="1"/><rect x="14" y="4" width="4" height="16" rx="1"/></svg>

--- a/src/icons/play.svg
+++ b/src/icons/play.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="6 4 20 12 6 20 6 4"/></svg>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,7 +1,7 @@
 ---
 import "../styles/global.css";
 import { ClientRouter } from "astro:transitions";
-import { EVENT_DETAILS } from "../lib/constants";
+import { EVENT } from "../data/event";
 import Analytics from "@vercel/analytics/astro";
 
 interface Props {
@@ -14,8 +14,8 @@ interface Props {
 
 const base = import.meta.env.BASE_URL;
 const {
-  title = "Darkness - Dark Theme",
-  description = "An intense motion-filled dark theme Astro site",
+  title = EVENT.name,
+  description = EVENT.mission,
   image: imageProp,
   ogType = "website",
 } = Astro.props;
@@ -117,7 +117,7 @@ const selfHostedFontFaces = `
     <link rel="canonical" href={canonicalUrl} />
 
     <meta property="og:type" content={ogType} />
-    <meta property="og:site_name" content={EVENT_DETAILS.NAME} />
+    <meta property="og:site_name" content={EVENT.name} />
     <meta property="og:title" content={title} />
     <meta property="og:description" content={description} />
     <meta property="og:url" content={canonicalUrl} />
@@ -150,7 +150,7 @@ const selfHostedFontFaces = `
   </head>
   <body>
     <a class="skip-link" href="#main-content">Skip to main content</a>
-    <div class="cursor-follower"></div>
+    <div class="cursor-follower" aria-hidden="true"></div>
     <div id="content-root">
       <slot />
     </div>
@@ -214,22 +214,27 @@ const selfHostedFontFaces = `
     </style>
 
     <script>
-      // Re-query cursor on each navigation — ClientRouter swaps the body, so the
-      // cached reference becomes stale after the first view-transition.
-      document.addEventListener("mousemove", (e) => {
-        const cursor = document.querySelector(
-          ".cursor-follower",
-        ) as HTMLElement | null;
-        if (!cursor) return;
-        cursor.style.left = e.clientX + "px";
-        cursor.style.top = e.clientY + "px";
-      });
+      /**
+       * Custom cursor. Disabled for coarse pointers (touch) and users who
+       * prefer reduced motion.
+       */
+      const supportsFineCursor =
+        window.matchMedia("(pointer: fine)").matches &&
+        !window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 
-      function initCursorHover() {
-        const cursor = document.querySelector(
-          ".cursor-follower",
-        ) as HTMLElement | null;
+      function initCursor() {
+        const cursor = document.querySelector<HTMLElement>(".cursor-follower");
         if (!cursor) return;
+
+        if (!supportsFineCursor) {
+          cursor.remove();
+          return;
+        }
+
+        document.addEventListener("mousemove", (e) => {
+          cursor.style.left = `${e.clientX}px`;
+          cursor.style.top = `${e.clientY}px`;
+        });
 
         document.querySelectorAll("a, button, .card").forEach((el) => {
           el.addEventListener("mouseenter", () => {
@@ -245,8 +250,7 @@ const selfHostedFontFaces = `
         });
       }
 
-      // astro:page-load fires on initial load and after every ClientRouter navigation.
-      document.addEventListener("astro:page-load", initCursorHover);
+      document.addEventListener("astro:page-load", initCursor);
     </script>
     <Analytics />
   </body>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -222,7 +222,13 @@ const selfHostedFontFaces = `
         window.matchMedia("(pointer: fine)").matches &&
         !window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 
+      let cursorAC: AbortController | undefined;
+
       function initCursor() {
+        cursorAC?.abort();
+        cursorAC = new AbortController();
+        const { signal } = cursorAC;
+
         const cursor = document.querySelector<HTMLElement>(".cursor-follower");
         if (!cursor) return;
 
@@ -231,22 +237,34 @@ const selfHostedFontFaces = `
           return;
         }
 
-        document.addEventListener("mousemove", (e) => {
-          cursor.style.left = `${e.clientX}px`;
-          cursor.style.top = `${e.clientY}px`;
-        });
+        document.addEventListener(
+          "mousemove",
+          (e) => {
+            cursor.style.left = `${e.clientX}px`;
+            cursor.style.top = `${e.clientY}px`;
+          },
+          { signal },
+        );
 
         document.querySelectorAll("a, button, .card").forEach((el) => {
-          el.addEventListener("mouseenter", () => {
-            cursor.style.width = "40px";
-            cursor.style.height = "40px";
-            cursor.style.backgroundColor = "rgba(168, 85, 247, 0.2)";
-          });
-          el.addEventListener("mouseleave", () => {
-            cursor.style.width = "20px";
-            cursor.style.height = "20px";
-            cursor.style.backgroundColor = "transparent";
-          });
+          el.addEventListener(
+            "mouseenter",
+            () => {
+              cursor.style.width = "40px";
+              cursor.style.height = "40px";
+              cursor.style.backgroundColor = "rgba(168, 85, 247, 0.2)";
+            },
+            { signal },
+          );
+          el.addEventListener(
+            "mouseleave",
+            () => {
+              cursor.style.width = "20px";
+              cursor.style.height = "20px";
+              cursor.style.backgroundColor = "transparent";
+            },
+            { signal },
+          );
         });
       }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,31 +1,85 @@
-/* Global styles for dark abyss theme */
+/* Hack Michigan Global Styles
+   --------------------------------------------------------------------------
+   Design tokens, element defaults, shared utilities, and keyframes.
+   Component-specific styles live in the component's <style> block.
+*/
+
 :root {
-  /* Color Palette - Developer Dark Theme */
+  /* ---- Color -- surfaces ---- */
   --color-bg-dark: #0f172a;
   --color-bg-darker: #020617;
   --color-bg-card: #1e293b;
+
+  /* ---- Color -- brand / accents ---- */
   --color-primary: #82b1fe;
   --color-primary-button: #3b82f6;
+  --color-primary-button-hover: #2563eb;
   --color-accent-purple: #8b5cf6;
   --color-accent-pink: #ec4899;
   --color-accent-orange: #fbbf24;
   --color-accent-orange-hover: #e6a800;
-  --color-accent-green: rgb(29, 255, 37);
+  --color-accent-green: rgb(29 255 37);
   --color-accent-blue: #3b82f6;
   --color-accent-cyan: #06b6d4;
-  --color-text: #f1f5f9;
-  --color-text-dim: rgb(193, 195, 197 / 100%);
-  --color-border: #334155;
-  --color-shadow: rgb(59, 130, 246 / 30%);
 
-  /* Typography */
+  /* ---- Color -- text & borders ---- */
+  --color-text: #f1f5f9;
+  --color-text-dim: #f1f5f9;
+  --color-border: #334155;
+  --color-shadow: rgb(59 130 246 / 30%);
+
+  /* ---- Typography ---- */
   --font-heading: "Tiny5", system-ui, sans-serif;
   --font-body: "Nunito", system-ui, sans-serif;
 
-  /* Spacing */
+  /* ---- Spacing scale (t-shirt) ---- */
+  --space-3xs: 0.25rem;
+  --space-2xs: 0.5rem;
+  --space-xs: 0.75rem;
+  --space-sm: 1rem;
+  --space-md: 1.5rem;
+  --space-lg: 2rem;
+  --space-xl: 3rem;
+  --space-2xl: 4rem;
+  --space-3xl: 5rem;
+
+  /* ---- Radius ---- */
+  --radius-sm: 0.5rem;
+  --radius-md: 0.75rem;
+  --radius-lg: 1rem;
+  --radius-xl: 1.25rem;
+  --radius-pill: 2rem;
+
+  /* ---- Shadows ---- */
+  --shadow-sm: 0 4px 14px rgb(59 130 246 / 35%);
+  --shadow-md: 0 6px 20px rgb(59 130 246 / 45%);
+  --shadow-lg: 0 12px 40px rgb(59 130 246 / 10%);
+  --shadow-glass: 0 20px 50px rgb(0 0 0 / 35%);
+
+  /* ---- Surfaces ---- */
+  --surface-glass-bg: rgb(30 41 59 / 55%);
+  --surface-glass-blur: 12px;
+
+  /* ---- Layout ---- */
   --nav-height: 80px;
   --anchor-scroll-margin: calc(var(--nav-height) + 1.25rem);
+  --container-max: 1200px;
+  --container-narrow: 900px;
+  --container-wide: 1400px;
+
+  /* ---- Breakpoints (reference; use in @media raw) ---- */
+  --bp-sm: 40rem; /* 640px */
+  --bp-md: 48rem; /* 768px */
+  --bp-lg: 64rem; /* 1024px */
+  --bp-xl: 80rem; /* 1280px */
+
+  /* ---- Motion ---- */
+  --ease-out: cubic-bezier(0.22, 1, 0.36, 1);
+  --duration-fast: 0.2s;
+  --duration-base: 0.3s;
 }
+
+/* Element defaults / Style Resets */
 
 * {
   box-sizing: border-box;
@@ -34,7 +88,6 @@
 }
 
 html {
-  /* Force dark native UI (scrollbars, form controls) regardless of OS theme */
   color-scheme: dark;
   font-family: var(--font-body);
   background: var(--color-bg-dark);
@@ -44,7 +97,12 @@ html {
   scroll-padding-top: var(--anchor-scroll-margin);
 }
 
-/* Headings use Tiny5 (self-hosted @font-face in BaseLayout.astro) */
+body {
+  min-height: 100vh;
+  position: relative;
+  overflow-x: hidden;
+}
+
 h1,
 h2,
 h3,
@@ -59,18 +117,12 @@ p {
   margin-block: 0.5rem 1rem;
 }
 
-body {
-  min-height: 100vh;
-  position: relative;
-  overflow-x: hidden;
-}
-
 /* Animated background gradient */
+
 body::before {
   content: "";
   position: fixed;
-  top: -50%;
-  left: -50%;
+  inset: -50% auto auto -50%;
   width: 200%;
   height: 200%;
   background:
@@ -93,17 +145,8 @@ body::before {
   z-index: -1;
 }
 
-@keyframes "gradient-shift" {
-  0% {
-    background-position: 0% 50%;
-  }
+/* Scrollbar */
 
-  100% {
-    background-position: 100% 50%;
-  }
-}
-
-/* Custom scrollbar */
 ::-webkit-scrollbar {
   width: 10px;
 }
@@ -125,11 +168,22 @@ body::before {
   background: linear-gradient(
     180deg,
     var(--color-accent-pink),
-    var(--color-accent-blue)
+    var(--color-primary-button)
   );
 }
 
-/* Global animations */
+/* Shared keyframes */
+
+@keyframes gradient-shift {
+  0% {
+    background-position: 0% 50%;
+  }
+
+  100% {
+    background-position: 100% 50%;
+  }
+}
+
 @keyframes float {
   0%,
   100% {
@@ -138,6 +192,17 @@ body::before {
 
   50% {
     transform: translateY(-20px);
+  }
+}
+
+@keyframes float-drift {
+  0%,
+  100% {
+    transform: translate(0, 0);
+  }
+
+  50% {
+    transform: translate(20px, -20px);
   }
 }
 
@@ -168,12 +233,50 @@ body::before {
   }
 }
 
+@keyframes fade-in-up {
+  from {
+    opacity: 0;
+    transform: translateY(30px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes slide-down {
+  from {
+    transform: translateY(-100%);
+    opacity: 0;
+  }
+
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@keyframes panel-reveal {
+  from {
+    opacity: 0;
+    transform: translateY(0.5rem);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Shared utilities */
+
 .shimmer-text {
   background: linear-gradient(
     90deg,
     var(--color-accent-purple),
     var(--color-accent-pink),
-    var(--color-accent-blue),
+    var(--color-primary-button),
     var(--color-accent-purple)
   );
   background-size: 200% auto;
@@ -181,4 +284,247 @@ body::before {
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   animation: text-shimmer 3s linear infinite;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Reduced-motion guardrail */
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* Shared surfaces -- glass card */
+
+.glass-card {
+  background: var(--surface-glass-bg);
+  border: 1px solid var(--color-border);
+  backdrop-filter: blur(var(--surface-glass-blur));
+  -webkit-backdrop-filter: blur(var(--surface-glass-blur));
+  border-radius: var(--radius-lg);
+}
+
+.glass-card--raised {
+  background: rgb(30 41 59 / 65%);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  box-shadow: var(--shadow-glass);
+}
+
+.glass-card--interactive {
+  transition:
+    border-color var(--duration-fast) ease,
+    box-shadow var(--duration-fast) ease;
+}
+
+.glass-card--interactive:hover {
+  border-color: rgb(59 130 246 / 35%);
+  box-shadow: 0 12px 40px rgb(59 130 246 / 10%);
+}
+
+.glass-card--interactive-violet:hover {
+  border-color: rgb(139 92 246 / 35%);
+  box-shadow: 0 12px 40px rgb(139 92 246 / 8%);
+}
+
+/* Shared containers & section rhythm */
+
+.section-container {
+  max-width: var(--container-max);
+  margin: 0 auto;
+}
+
+.section-container--narrow {
+  max-width: var(--container-narrow);
+}
+
+.section-container--wide {
+  max-width: var(--container-wide);
+}
+
+.section-title {
+  font-family: var(--font-heading);
+  font-size: clamp(2rem, 5vw, 3rem);
+  font-weight: 700;
+  text-align: center;
+  margin-bottom: 0.75rem;
+  color: var(--color-accent-green);
+}
+
+#about .section-title {
+  margin-block-start: 2rem;
+}
+
+/*
+ * Cross-component card overrides
+ * Astro scoped styles can't target classes rendered by child components
+ * (GlassCard gets a different data-astro-cid scope). Use section IDs to
+ * keep specificity tight.
+ */
+
+#about .about-card {
+  padding: 2rem 2.25rem;
+}
+
+#event-details .detail-card {
+  padding: 2rem;
+}
+
+#logistics .log-card {
+  padding: 1.75rem;
+}
+
+#signup .section-container--narrow {
+  max-width: 720px;
+}
+
+#signup .signup-card {
+  padding: 2.25rem 2rem;
+  text-align: center;
+}
+
+.section-subtitle {
+  text-align: center;
+  color: var(--color-text);
+  font-size: 1.1rem;
+  line-height: normal;
+  margin: 0.5rem auto 2rem;
+  max-width: 720px;
+}
+
+.section-eyebrow {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--color-primary);
+  margin-bottom: 0.75rem;
+}
+
+/* Shared action -- buttons */
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2xs);
+  padding: 0.875rem 1.75rem;
+  font-size: 1rem;
+  font-weight: 600;
+  font-family: var(--font-body);
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition:
+    background-color var(--duration-fast) ease,
+    border-color var(--duration-fast) ease,
+    box-shadow var(--duration-fast) ease,
+    color var(--duration-fast) ease,
+    transform var(--duration-fast) ease;
+}
+
+.btn-primary {
+  background: var(--color-accent-orange);
+  color: #000;
+  border: none;
+  box-shadow: var(--shadow-sm);
+}
+
+.btn-primary:hover {
+  background: var(--color-accent-orange-hover);
+  box-shadow: var(--shadow-md);
+}
+
+.btn-primary svg {
+  transition: transform var(--duration-fast) ease;
+}
+
+.btn-primary:hover svg {
+  transform: translateX(4px);
+}
+
+.btn-secondary {
+  background: transparent;
+  color: var(--color-accent-orange);
+  border: 3px solid var(--color-accent-orange);
+}
+
+.btn-secondary:hover {
+  background: rgb(251 191 36 / 8%);
+  border-color: rgb(252 211 77 / 85%);
+}
+
+.btn-ghost {
+  background: transparent;
+  color: var(--color-text);
+  border-color: var(--color-border);
+}
+
+.btn-ghost:hover {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+
+.btn-mega {
+  padding: 1rem 2rem;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--color-bg-dark);
+  background: #f8fafc;
+  border: none;
+  box-shadow: 0 8px 30px rgb(0 0 0 / 25%);
+  text-transform: none;
+  gap: normal;
+}
+
+.btn-mega:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 40px rgb(0 0 0 / 35%);
+}
+
+.btn-sponsor-glow {
+  border-color: rgb(251 191 36 / 55%);
+  box-shadow:
+    0 0 0 1px rgb(251 191 36 / 12%),
+    0 0 20px rgb(251 191 36 / 35%),
+    0 0 44px rgb(245 158 11 / 22%);
+}
+
+.btn-sponsor-glow:hover {
+  background: rgb(251 191 36 / 8%);
+  border-color: rgb(252 211 77 / 85%);
+  box-shadow:
+    0 0 0 1px rgb(252 211 77 / 20%),
+    0 0 26px rgb(251 191 36 / 50%),
+    0 0 52px rgb(245 158 11 / 32%);
+}
+
+@media (max-width: 48rem) {
+  .btn-block-on-mobile {
+    width: 100%;
+    max-width: 320px;
+  }
+
+  #about .about-card {
+    padding: 1.5rem 1.25rem;
+  }
 }

--- a/stylelint.config.mjs
+++ b/stylelint.config.mjs
@@ -1,6 +1,7 @@
 /** @type {import("stylelint").Config} */
 export default {
   extends: ["stylelint-config-standard"],
+  plugins: ["stylelint-order"],
   rules: {
     // Keep this repo flexible; we mainly want to catch actual CSS mistakes,
     // not enforce modernized color notation or strict selector conventions.
@@ -22,9 +23,15 @@ export default {
       true,
       { ignorePseudoClasses: ["global"] },
     ],
-    "shorthand-property-no-redundant-values": null,
-    "length-zero-no-unit": null,
     "value-keyword-case": null,
+    // Consistent ordering of custom properties within a declaration block.
+    "order/order": [
+      "custom-properties",
+      "dollar-variables",
+      "declarations",
+      "rules",
+      "at-rules",
+    ],
   },
   overrides: [
     {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,10 @@
   "extends": "astro/tsconfigs/strictest",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "jsxImportSource": "astro"
+    "jsxImportSource": "astro",
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["src/*"]
+    }
   }
 }


### PR DESCRIPTION
Maintain parity with current live site while introducing atomic design to make more maintainable long term

- add `stylelint-order` dep & related dev script
- Create primitives: Button, GlassCard, Icon, MaybeLink, Section, SectionHeader
- Extract SponsorTier sub-component from SponsorsSection
- Add typed data modules: event, nav, socials, logistics
- Add SVG icon set: arrow-right, calendar, map-pin, menu, pause, play
- Migrate all sections components to use primitives and data modules
- Establish design token system in global.css
- Add cross-component card overrides via ID-scoped selectors