### PR TITLE
refactor: add IBM platform access code to hero, signup, & agentic CTA

### DIFF
--- a/src/components/FinalAgenticCTA.astro
+++ b/src/components/FinalAgenticCTA.astro
@@ -16,6 +16,9 @@ import { EVENT_URLS } from "../data/event";
     <Button href={EVENT_URLS.hackerRegistration} variant="mega">
       Go to IBM Agentic
     </Button>
+    <p class="access-code-hint">
+      Access code: <span class="access-code">HACKMI</span>
+    </p>
   </div>
 </section>
 
@@ -66,6 +69,28 @@ import { EVENT_URLS } from "../data/event";
     line-height: 1.65;
     color: var(--color-text-dim);
     margin-bottom: 1.75rem;
+  }
+
+  .access-code-hint {
+    font-size: 0.8rem;
+    color: var(--color-text-dim);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    margin-top: 1.25rem;
+    opacity: 0.8;
+  }
+
+  .access-code {
+    display: inline-block;
+    font-family: monospace;
+    font-weight: 700;
+    font-size: 1em;
+    color: var(--color-accent-orange);
+    background: rgb(251 191 36 / 12%);
+    padding: 0.1em 0.45em;
+    border-radius: 4px;
+    border: 1px solid rgb(251 191 36 / 50%);
+    letter-spacing: 0.12em;
   }
 
   @media (max-width: 48rem) {

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -34,6 +34,10 @@ const base = import.meta.env.BASE_URL;
       </Button>
     </div>
 
+    <p class="access-code-hint">
+      IBM platform access code: <span class="access-code">HACKMI</span>
+    </p>
+
     <p class="hero-description">
       Michigan was built by innovators—and it's time to innovate again. Build an
       AI + open-source proof of concept that modernizes a Michigan industry.
@@ -127,7 +131,29 @@ const base = import.meta.env.BASE_URL;
     gap: 1rem;
     justify-content: center;
     flex-wrap: wrap;
-    margin-block: 3rem;
+    margin-block: 3rem 1rem;
+  }
+
+  .access-code-hint {
+    font-size: 0.8rem;
+    color: var(--color-text-dim);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    margin-bottom: 2rem;
+    opacity: 0.8;
+  }
+
+  .access-code {
+    display: inline-block;
+    font-family: monospace;
+    font-weight: 700;
+    font-size: 1em;
+    color: var(--color-accent-orange);
+    background: rgb(251 191 36 / 12%);
+    padding: 0.1em 0.45em;
+    border-radius: 4px;
+    border: 1px solid rgb(251 191 36 / 50%);
+    letter-spacing: 0.12em;
   }
 
   .hero-chips {

--- a/src/components/SignupSection.astro
+++ b/src/components/SignupSection.astro
@@ -21,6 +21,9 @@ import { EVENT_URLS } from "../data/event";
     <Button href={EVENT_URLS.hackerRegistration}>
       Register for Hack Michigan
     </Button>
+    <p class="access-code-hint">
+      IBM platform access code: <span class="access-code">HACKMI</span>
+    </p>
   </GlassCard>
 </Section>
 
@@ -39,5 +42,27 @@ import { EVENT_URLS } from "../data/event";
     font-size: 1.05rem;
     line-height: 1.65;
     margin-bottom: 1.5rem;
+  }
+
+  .access-code-hint {
+    font-size: 0.8rem;
+    color: var(--color-text-dim);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    margin-top: 1rem;
+    opacity: 0.8;
+  }
+
+  .access-code {
+    display: inline-block;
+    font-family: monospace;
+    font-weight: 700;
+    font-size: 1em;
+    color: var(--color-accent-orange);
+    background: rgb(251 191 36 / 12%);
+    padding: 0.1em 0.45em;
+    border-radius: 4px;
+    border: 1px solid rgb(251 191 36 / 50%);
+    letter-spacing: 0.12em;
   }
 </style>


### PR DESCRIPTION
- Add IBM platform access code to hero, signup, and agentic cta

<img width="674" height="193" alt="hero" src="https://github.com/user-attachments/assets/5dd7af04-e68c-4da2-9711-abdb18fea2b3" />
<img width="698" height="310" alt="join_list" src="https://github.com/user-attachments/assets/2fd90f40-54eb-4af7-a94c-6b1bc084b17b" />
<img width="797" height="441" alt="agentic_cta" src="https://github.com/user-attachments/assets/803ee033-829e-4e4b-96d5-e68c0df1c61f" />


